### PR TITLE
Fix vectorized ops in CPU kernels

### DIFF
--- a/dev/packaging/gen_wheel_index.sh
+++ b/dev/packaging/gen_wheel_index.sh
@@ -15,7 +15,7 @@ export LC_ALL=C  # reproducible sort
 index=$root/index.html
 
 cd "$root"
-for cu in cpu cu101 cu102 cu111 cu113 cu115 cu116; do
+for cu in cpu cu101 cu102 cu111 cu113 cu115 cu116 cu117; do
   mkdir -p "$root/$cu"
   cd "$root/$cu"
   echo "Creating $PWD/index.html ..."

--- a/example.MANIFEST.in
+++ b/example.MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include natten *.cpp *.cuh *.cu *.h 
+prune tests/
+graft assets/

--- a/natten/src/cpp/natten1dqkrpb_cpu_kernel.cpp
+++ b/natten/src/cpp/natten1dqkrpb_cpu_kernel.cpp
@@ -55,10 +55,11 @@ void natten1dqkrpb_cpu_forward_kernel(
             int64_t d1 = 0;
             for (; d1 < dim - (dim % Vec::size()); d1+=Vec::size())
                 updt = at::vec::fmadd(Vec::loadu(_qaddr + d1), Vec::loadu(_kaddr + d1), updt);
+            scalar_t sum_val = at::vec::vec_reduce_all([](Vec& x, Vec& y) { return x + y; }, updt, Vec::size());
             for (; d1 < dim; ++d1)
-                updt[d1] += _qaddr[d1] * _kaddr[d1];
+                sum_val += _qaddr[d1] * _kaddr[d1];
             const int rpbIndex = h * rpb.stride(0) + (pi+ki) * rpb.stride(1);
-            attn.data()[index] = rpb.data()[rpbIndex] + at::vec::vec_reduce_all([](Vec& x, Vec& y) { return x + y; }, updt, Vec::size());
+            attn.data()[index] = rpb.data()[rpbIndex] + sum_val;
             index++;
         }
     }});


### PR DESCRIPTION
Incorrect usage of torch's vector definitions might cause compile issues for certain users, or worse, result in runtime issues when head dims are not multiples of vec size.