### PR TITLE
Fix CUDA memory allocation

### DIFF
--- a/src/natten/backend.py
+++ b/src/natten/backend.py
@@ -1,0 +1,76 @@
+"""
+Neighborhood Attention Autograd Functions
+
+This source code is licensed under the license found in the
+LICENSE file in the root directory of this source tree.
+"""
+import torch
+from torch.autograd import Function
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+try:
+    from natten import _C
+except ImportError:
+    raise ImportError(
+        f"Failed to import NATTEN's Cython backend. "
+        + f"This could be due to an invalid/incomplete install. "
+        + f"Please uninstall NATTEN (pip uninstall natten) and re-install with the"
+        f" correct torch build: "
+        + f"shi-labs.com/natten"
+    )
+
+
+def natten1dqkrpb_forward(query, key, rpb, kernel_size, dilation):
+    if query.is_cuda:
+        with torch.cuda.device(query.device):
+            return _C.natten1dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+    return _C.natten1dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+
+
+def natten2dqkrpb_forward(query, key, rpb, kernel_size, dilation):
+    if query.is_cuda:
+        with torch.cuda.device(query.device):
+            return _C.natten2dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+    return _C.natten2dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+
+
+def natten1dav_forward(attn, value, dilation):
+    if attn.is_cuda:
+        with torch.cuda.device(attn.device):
+            return _C.natten1dav_forward(attn, value, dilation)
+    return _C.natten1dav_forward(attn, value, dilation)
+
+
+def natten2dav_forward(attn, value, dilation):
+    if attn.is_cuda:
+        with torch.cuda.device(attn.device):
+            return _C.natten2dav_forward(attn, value, dilation)
+    return _C.natten2dav_forward(attn, value, dilation)
+
+
+def natten1dqkrpb_backward(d_attn, query, key, has_bias, dilation):
+    if query.is_cuda:
+        with torch.cuda.device(query.device):
+            return _C.natten1dqkrpb_backward(d_attn, query, key, has_bias, dilation)
+    return _C.natten1dqkrpb_backward(d_attn, query, key, has_bias, dilation)
+
+
+def natten2dqkrpb_backward(d_attn, query, key, has_bias, dilation):
+    if query.is_cuda:
+        with torch.cuda.device(query.device):
+            return _C.natten2dqkrpb_backward(d_attn, query, key, has_bias, dilation)
+    return _C.natten2dqkrpb_backward(d_attn, query, key, has_bias, dilation)
+
+
+def natten1dav_backward(d_out, attn, value, dilation):
+    if attn.is_cuda:
+        with torch.cuda.device(attn.device):
+            return _C.natten1dav_backward(d_out, attn, value, dilation)
+    return _C.natten1dav_backward(d_out, attn, value, dilation)
+
+
+def natten2dav_backward(d_out, attn, value, dilation):
+    if attn.is_cuda:
+        with torch.cuda.device(attn.device):
+            return _C.natten2dav_backward(d_out, attn, value, dilation)
+    return _C.natten2dav_backward(d_out, attn, value, dilation)

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -8,16 +8,7 @@ import torch
 from torch.autograd import Function
 from torch.cuda.amp import custom_bwd, custom_fwd
 
-try:
-    from natten import _C
-except ImportError:
-    raise ImportError(
-        f"Failed to import NATTEN's CPP backend. "
-        + f"This could be due to an invalid/incomplete install. "
-        + f"Please uninstall NATTEN (pip uninstall natten) and re-install with the"
-        f" correct torch build: "
-        + f"natten.shi-labs.com."
-    )
+from . import backend
 
 
 class NATTEN1DQKRPBFunction(Function):
@@ -33,7 +24,7 @@ class NATTEN1DQKRPBFunction(Function):
     def forward(ctx, query, key, rpb, kernel_size, dilation):
         query = query.contiguous()
         key = key.contiguous()
-        attn = _C.natten1dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+        attn = backend.natten1dqkrpb_forward(query, key, rpb, kernel_size, dilation)
         ctx.save_for_backward(query, key)
         ctx.dilation = dilation
         ctx.bias = rpb is not None
@@ -42,7 +33,7 @@ class NATTEN1DQKRPBFunction(Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.natten1dqkrpb_backward(
+        outputs = backend.natten1dqkrpb_backward(
             grad_out.contiguous(),
             ctx.saved_variables[0],
             ctx.saved_variables[1],
@@ -65,7 +56,7 @@ class NATTEN1DAVFunction(Function):
     def forward(ctx, attn, value, dilation):
         attn = attn.contiguous()
         value = value.contiguous()
-        out = _C.natten1dav_forward(attn, value, dilation)
+        out = backend.natten1dav_forward(attn, value, dilation)
         ctx.save_for_backward(attn, value)
         ctx.dilation = dilation
         return out
@@ -73,7 +64,7 @@ class NATTEN1DAVFunction(Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.natten1dav_backward(
+        outputs = backend.natten1dav_backward(
             grad_out.contiguous(),
             ctx.saved_variables[0],
             ctx.saved_variables[1],
@@ -96,7 +87,7 @@ class NATTEN2DQKRPBFunction(Function):
     def forward(ctx, query, key, rpb, kernel_size, dilation):
         query = query.contiguous()
         key = key.contiguous()
-        attn = _C.natten2dqkrpb_forward(query, key, rpb, kernel_size, dilation)
+        attn = backend.natten2dqkrpb_forward(query, key, rpb, kernel_size, dilation)
         ctx.save_for_backward(query, key)
         ctx.dilation = dilation
         ctx.bias = rpb is not None
@@ -105,7 +96,7 @@ class NATTEN2DQKRPBFunction(Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.natten2dqkrpb_backward(
+        outputs = backend.natten2dqkrpb_backward(
             grad_out.contiguous(),
             ctx.saved_variables[0],
             ctx.saved_variables[1],
@@ -128,7 +119,7 @@ class NATTEN2DAVFunction(Function):
     def forward(ctx, attn, value, dilation):
         attn = attn.contiguous()
         value = value.contiguous()
-        out = _C.natten2dav_forward(attn, value, dilation)
+        out = backend.natten2dav_forward(attn, value, dilation)
         ctx.save_for_backward(attn, value)
         ctx.dilation = dilation
         return out
@@ -136,7 +127,7 @@ class NATTEN2DAVFunction(Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.natten2dav_backward(
+        outputs = backend.natten2dav_backward(
             grad_out.contiguous(),
             ctx.saved_variables[0],
             ctx.saved_variables[1],

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -35,8 +35,8 @@ class NATTEN1DQKRPBFunction(Function):
     def backward(ctx, grad_out):
         outputs = backend.natten1dqkrpb_backward(
             grad_out.contiguous(),
-            ctx.saved_variables[0],
-            ctx.saved_variables[1],
+            ctx.saved_tensors[0],
+            ctx.saved_tensors[1],
             ctx.bias,
             ctx.dilation,
         )
@@ -66,8 +66,8 @@ class NATTEN1DAVFunction(Function):
     def backward(ctx, grad_out):
         outputs = backend.natten1dav_backward(
             grad_out.contiguous(),
-            ctx.saved_variables[0],
-            ctx.saved_variables[1],
+            ctx.saved_tensors[0],
+            ctx.saved_tensors[1],
             ctx.dilation,
         )
         d_attn, d_value = outputs
@@ -98,8 +98,8 @@ class NATTEN2DQKRPBFunction(Function):
     def backward(ctx, grad_out):
         outputs = backend.natten2dqkrpb_backward(
             grad_out.contiguous(),
-            ctx.saved_variables[0],
-            ctx.saved_variables[1],
+            ctx.saved_tensors[0],
+            ctx.saved_tensors[1],
             ctx.bias,
             ctx.dilation,
         )
@@ -129,8 +129,8 @@ class NATTEN2DAVFunction(Function):
     def backward(ctx, grad_out):
         outputs = backend.natten2dav_backward(
             grad_out.contiguous(),
-            ctx.saved_variables[0],
-            ctx.saved_variables[1],
+            ctx.saved_tensors[0],
+            ctx.saved_tensors[1],
             ctx.dilation,
         )
         d_attn, d_value = outputs


### PR DESCRIPTION
## Issue
Looks like we missed this in our test environments (first raised in #13 ), but our CUDA backend seems to reserve a couple of hundred megabytes on `cuda:0` when torch's device is not explicitly set. While it is avoided in most cases (DDP scripts typically set torch's cuda device per process), this might raise an issue for users who either don't use a torch device wrapper or set a global torch device. 

## Potential cause
According to [this thread](https://discuss.pytorch.org/t/memory-leak-due-to-a-tensor-created-with-thcudatensor-newwithsize2d-in-an-extension/22430) , this is due to reserving CUDA memory through the ATen API, and the correct way of doing it is to create output tensors within the python interface, and pass the output tensors to the backend.

This remains to be investigated.

## What's this PR for then?
The solution here temporarily resolves the issue by sending every call to the backend through a `torch.cuda.device` wrapper set to the first input's cuda device (if it is on cuda; ignored if cpu).

Tests pass, there's no expected effects on outputs at all.

I am however disinclined to merge this right away without first checking if it affects performance. Highly unlikely, but in case it does we might want to explore other options.
We also might want to just go ahead and move the memory allocation from the backend to python.

## Misc
Also switched from `saved_variables` to `saved_tensors` in the autograd functions; the former has been marked deprecated for some time.

