### PR TITLE
Ban invalid problem sizes in api

### DIFF
--- a/csrc/src/pytorch/na1d.cpp
+++ b/csrc/src/pytorch/na1d.cpp
@@ -43,6 +43,8 @@ at::Tensor na1d_qk_forward(
     const at::optional<at::Tensor> &bias,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     TORCH_CHECK(query.scalar_type() == key.scalar_type(), "Query and key tensors must match in dtype.");
@@ -85,6 +87,8 @@ std::vector<at::Tensor> na1d_qk_backward(
     const bool has_bias,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     CHECK_CONTIGUOUS(d_attn);
@@ -133,6 +137,8 @@ at::Tensor na1d_av_forward(
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     TORCH_CHECK(attn.scalar_type() == value.scalar_type(), "Attention and value tensors must match in dtype.");
@@ -164,6 +170,8 @@ std::vector<at::Tensor> na1d_av_backward(
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     CHECK_CONTIGUOUS(d_out);

--- a/csrc/src/pytorch/na2d.cpp
+++ b/csrc/src/pytorch/na2d.cpp
@@ -43,6 +43,8 @@ at::Tensor na2d_qk_forward(
     const at::optional<at::Tensor> &bias,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     TORCH_CHECK(query.scalar_type() == key.scalar_type(), "Query and key tensors must match in dtype.");
@@ -89,6 +91,8 @@ std::vector<at::Tensor> na2d_qk_backward(
     const bool has_bias,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     CHECK_CONTIGUOUS(d_attn);
@@ -141,6 +145,8 @@ at::Tensor na2d_av_forward(
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     TORCH_CHECK(attn.scalar_type() == value.scalar_type(), "Attention and value tensors must match in dtype.");
@@ -175,6 +181,8 @@ std::vector<at::Tensor> na2d_av_backward(
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     CHECK_CONTIGUOUS(d_out);

--- a/csrc/src/pytorch/na3d.cpp
+++ b/csrc/src/pytorch/na3d.cpp
@@ -45,6 +45,9 @@ at::Tensor na3d_qk_forward(
     const int dilation,
     const int depth_kernel_size,
     const int depth_dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(depth_kernel_size > 1 && depth_kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1 && depth_dilation, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     TORCH_CHECK(query.scalar_type() == key.scalar_type(), "Query and key tensors must match in dtype.");
@@ -97,6 +100,9 @@ std::vector<at::Tensor> na3d_qk_backward(
     const int dilation,
     const int depth_kernel_size,
     const int depth_dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(depth_kernel_size > 1 && depth_kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1 && depth_dilation, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(query);
     CHECK_CONTIGUOUS(key);
     CHECK_CONTIGUOUS(d_attn);
@@ -155,6 +161,9 @@ at::Tensor na3d_av_forward(
     const int dilation,
     const int depth_kernel_size,
     const int depth_dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(depth_kernel_size > 1 && depth_kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1 && depth_dilation, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     TORCH_CHECK(attn.scalar_type() == value.scalar_type(), "Attention and value tensors must match in dtype.");
@@ -193,6 +202,9 @@ std::vector<at::Tensor> na3d_av_backward(
     const int dilation,
     const int depth_kernel_size,
     const int depth_dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(depth_kernel_size > 1 && depth_kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
+    TORCH_CHECK(dilation >= 1 && depth_dilation, "Dilation must be a nonnegative integer.");
     CHECK_CONTIGUOUS(attn);
     CHECK_CONTIGUOUS(value);
     CHECK_CONTIGUOUS(d_out);

--- a/tests/test_na1d.py
+++ b/tests/test_na1d.py
@@ -293,6 +293,18 @@ class NA1DTests(unittest.TestCase):
             B=1, H=2, L=64, D=16, kernel_size=21, dilation=2, eps=1e-6, device="cuda"
         )
 
+    @unittest.expectedFailure
+    def test_invalid_kernel_size(self):
+        self._test_autograd(
+            B=2, H=2, L=16, D=8, kernel_size=8, dilation=1, eps=1e-6, device="cpu"
+        )
+
+    @unittest.expectedFailure
+    def test_invalid_dilation(self):
+        self._test_autograd(
+            B=2, H=2, L=16, D=8, kernel_size=5, dilation=0, eps=1e-6, device="cpu"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_na2d.py
+++ b/tests/test_na2d.py
@@ -373,6 +373,18 @@ class NA2DTests(unittest.TestCase):
             B=1, H=1, X=7, Y=6, D=8, kernel_size=3, dilation=2, eps=1e-6, device="cuda"
         )
 
+    @unittest.expectedFailure
+    def test_invalid_kernel_size(self):
+        self._test_autograd(
+            B=1, H=1, X=8, Y=9, D=8, kernel_size=8, dilation=1, eps=1e-6, device="cuda"
+        )
+
+    @unittest.expectedFailure
+    def test_invalid_dilation(self):
+        self._test_autograd(
+            B=1, H=1, X=8, Y=9, D=8, kernel_size=5, dilation=0, eps=1e-6, device="cuda"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_na3d.py
+++ b/tests/test_na3d.py
@@ -233,6 +233,36 @@ class NA3DTests(unittest.TestCase):
             device="cuda",
         )
 
+    @unittest.expectedFailure
+    def test_invalid_kernel_size(self):
+        self._test_autograd(
+            B=1,
+            H=2,
+            X=6,
+            Y=3,
+            Z=8,
+            D=8,
+            kernel_size=2,
+            dilation=1,
+            eps=1e-6,
+            device="cuda",
+        )
+
+    @unittest.expectedFailure
+    def test_invalid_dilation(self):
+        self._test_autograd(
+            B=1,
+            H=2,
+            X=6,
+            Y=3,
+            Z=8,
+            D=8,
+            kernel_size=3,
+            dilation=0,
+            eps=1e-6,
+            device="cuda",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
API should ban invalid inputs to prevent kernels from even being called in the first place.
Either I never did this before the refactor and relied on the python front end (which is not a good idea; users should be able to call the ops directly without going through the modules), or it wasn't rewritten in the refactor, but anyways, here's the fix.

References: #41 and #48 .