### PR TITLE
Nested Tensor Support

### DIFF
--- a/csrc/include/natten/pytorch/cpu/na1d.h
+++ b/csrc/include/natten/pytorch/cpu/na1d.h
@@ -49,7 +49,7 @@ void na1d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int length,

--- a/csrc/include/natten/pytorch/cpu/na2d.h
+++ b/csrc/include/natten/pytorch/cpu/na2d.h
@@ -50,7 +50,7 @@ void na2d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int height,

--- a/csrc/include/natten/pytorch/cpu/na3d.h
+++ b/csrc/include/natten/pytorch/cpu/na3d.h
@@ -53,7 +53,7 @@ void na3d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int depth,

--- a/csrc/include/natten/pytorch/cuda/na1d.cuh
+++ b/csrc/include/natten/pytorch/cuda/na1d.cuh
@@ -49,7 +49,7 @@ void na1d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int length,

--- a/csrc/include/natten/pytorch/cuda/na2d.cuh
+++ b/csrc/include/natten/pytorch/cuda/na2d.cuh
@@ -50,7 +50,7 @@ void na2d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int height,

--- a/csrc/include/natten/pytorch/cuda/na3d.cuh
+++ b/csrc/include/natten/pytorch/cuda/na3d.cuh
@@ -53,7 +53,7 @@ void na3d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int depth,

--- a/csrc/include/natten/pytorch/helpers.h
+++ b/csrc/include/natten/pytorch/helpers.h
@@ -62,3 +62,101 @@
     }                                                                                              \
   }()
 #endif
+
+namespace natten {
+namespace pytorch {
+
+inline void CheckArgs(int kernel_size, int dilation) {
+    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1, got ", kernel_size, ".");
+    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer, got ", dilation, ".");
+}
+
+inline void CheckArgsAgainstDim(int dim, int kernel_size, int dilation) {
+    TORCH_CHECK(kernel_size * dilation <= dim, "Input axes must be less than or equal to the product of kernel size and dilation. "
+            "Got kernel size ", kernel_size, ", dilation ", dilation, ", but dimension size was ", dim, ".");
+}
+
+inline void CheckIfPropertiesMatch(const at::Tensor& a, const at::Tensor& b) {
+    CHECK_CONTIGUOUS(a);
+    CHECK_CONTIGUOUS(b);
+    TORCH_CHECK(a.device().is_cuda() == b.device().is_cuda(), "Expected all tensors to be on the same device.");
+    TORCH_CHECK(a.scalar_type() == b.scalar_type(), "Input tensors must match in dtype!");
+}
+
+inline void CheckIfPropertiesMatch(const at::Tensor& a, const at::Tensor& b, const at::Tensor& c) {
+    CHECK_CONTIGUOUS(a);
+    CHECK_CONTIGUOUS(b);
+    CHECK_CONTIGUOUS(c);
+    TORCH_CHECK(a.device().is_cuda() == b.device().is_cuda() && b.device().is_cuda() == c.device().is_cuda(), "Expected all tensors to be on the same device.");
+    TORCH_CHECK(a.scalar_type() == b.scalar_type() && b.scalar_type() == c.scalar_type(), "Input tensors must match in dtype!");
+}
+
+template <size_t NaDim>
+void CheckIfTensorShapesMatch(const at::Tensor& a, const at::Tensor& b) {
+    static_assert(NaDim >= 1 && NaDim < 4);
+    static constexpr size_t Rank = NaDim + 3;
+    TORCH_CHECK(a.dim() == b.dim() && a.dim() == Rank, "Expected ", Rank, "-D tensors.");
+    for (size_t i=0; i < Rank; ++i) {
+        TORCH_CHECK(a.size(i) == b.size(i), "Tensor shape mismatch at dimension ", i, ": ", a.size(i), " != ", b.size(i));
+    }
+}
+
+template <size_t NaDim>
+void CheckAttnShape(const at::Tensor& input, const at::Tensor& attn, int kernel_size) {
+    static_assert(NaDim >= 1 && NaDim < 4);
+    TORCH_CHECK(attn.dim() == NaDim + 3, "Expected ", NaDim + 3, "-D tensors.");
+    for (size_t i=0; i < NaDim + 2; ++i) {
+        TORCH_CHECK(input.size(i) == attn.size(i), "Tensor shape mismatch at dimension ", i, ": ", input.size(i), " != ", input.size(i));
+    }
+    auto expected_kernel_size = std::pow(kernel_size, NaDim);
+    TORCH_CHECK(attn.size(NaDim + 2) == expected_kernel_size, "Expected attention dim was ", expected_kernel_size, ", got ", attn.size(NaDim + 2));
+}
+
+template <size_t NaDim>
+void CheckBias(const at::Tensor& input, const at::Tensor& bias, int kernel_size) {
+    static_assert(NaDim >= 1 && NaDim < 4);
+    TORCH_CHECK(input.scalar_type() == bias.scalar_type(), "Inputs and bias must match in dtype.");
+    TORCH_CHECK(bias.device().is_cuda() == input.device().is_cuda(), 
+            "Expected positional bias to be on the same device as the inputs.");
+    CHECK_CONTIGUOUS(bias);
+    TORCH_CHECK(bias.size(0) == input.size(1), "Expected bias.shape[0] == input.shape[1] == heads.");
+    for (size_t i=0; i < NaDim; ++i) {
+        auto expected_bias_dim = kernel_size * 2 - 1;
+        TORCH_CHECK(bias.size(i + 1) == expected_bias_dim, "Invalid bias shape at dim ", i + 1, "; "
+                "expected ", expected_bias_dim, ", got ", bias.size(i + 1), ".");
+    }
+}
+
+// TODO: I resent this; please do it the right way.
+template <size_t NaDim>
+void CheckAttnShape(const at::Tensor& input, const at::Tensor& attn, int kernel_size, int kernel_size_d) {
+    static_assert(NaDim == 3);
+    TORCH_CHECK(attn.dim() == NaDim + 3, "Expected ", NaDim + 3, "-D tensors.");
+    for (size_t i=0; i < NaDim + 2; ++i) {
+        TORCH_CHECK(input.size(i) == attn.size(i), "Tensor shape mismatch at dimension ", i, ": ", input.size(i), " != ", input.size(i));
+    }
+    auto expected_kernel_size = kernel_size * kernel_size * kernel_size_d;
+    TORCH_CHECK(attn.size(NaDim + 2) == expected_kernel_size, "Expected attention dim was ", expected_kernel_size, ", got ", attn.size(NaDim + 2));
+}
+
+template <size_t NaDim>
+void CheckBias(const at::Tensor& input, const at::Tensor& bias, int kernel_size, int kernel_size_d) {
+    static_assert(NaDim ==3);
+    TORCH_CHECK(input.scalar_type() == bias.scalar_type(), "Inputs and bias must match in dtype.");
+    TORCH_CHECK(bias.device().is_cuda() == input.device().is_cuda(), 
+            "Expected positional bias to be on the same device as the inputs.");
+    CHECK_CONTIGUOUS(bias);
+    TORCH_CHECK(bias.size(0) == input.size(1), "Expected bias.shape[0] == input.shape[1] == heads.");
+
+    auto expected_bias_dim_0 = kernel_size_d * 2 - 1;
+    TORCH_CHECK(bias.size(1) == expected_bias_dim_0, "Invalid bias shape at dim 1; expected ", 
+        expected_bias_dim_0, ", got ", bias.size(1), ".");
+    for (size_t i=1; i < NaDim; ++i) {
+        auto expected_bias_dim = kernel_size * 2 - 1;
+        TORCH_CHECK(bias.size(i + 1) == expected_bias_dim, "Invalid bias shape at dim ", i + 1, "; "
+                "expected ", expected_bias_dim, ", got ", bias.size(i + 1), ".");
+    }
+}
+
+} // namespace pytorch
+} // namespace natten

--- a/csrc/include/natten/pytorch/na1d.h
+++ b/csrc/include/natten/pytorch/na1d.h
@@ -26,33 +26,38 @@
 
 #pragma once
 #include <ATen/ATen.h>
-#include <vector>
 
 namespace natten {
 namespace pytorch {
 
-at::Tensor na1d_qk_forward(
+void na1d_qk_forward(
+    at::Tensor &attn,
     const at::Tensor &query,
     const at::Tensor &key,
     const at::optional<at::Tensor> &bias,
     const int kernel_size,
     const int dilation);
 
-std::vector<at::Tensor> na1d_qk_backward(
+void na1d_qk_backward(
+    at::Tensor &d_query,
+    at::Tensor &d_key,
+    at::optional<at::Tensor> &d_bias,
     const at::Tensor &d_attn,
     const at::Tensor &query,
     const at::Tensor &key,
-    const bool has_bias,
     const int kernel_size,
     const int dilation);
 
-at::Tensor na1d_av_forward(
+void na1d_av_forward(
+    at::Tensor &out,
     const at::Tensor &attn,
     const at::Tensor &value,
     const int kernel_size,
     const int dilation);
 
-std::vector<at::Tensor> na1d_av_backward(
+void na1d_av_backward(
+    at::Tensor &d_attn,
+    at::Tensor &d_value,
     const at::Tensor &d_out,
     const at::Tensor &attn,
     const at::Tensor &value,

--- a/csrc/include/natten/pytorch/na2d.h
+++ b/csrc/include/natten/pytorch/na2d.h
@@ -26,33 +26,38 @@
 
 #pragma once
 #include <ATen/ATen.h>
-#include <vector>
 
 namespace natten {
 namespace pytorch {
 
-at::Tensor na2d_qk_forward(
+void na2d_qk_forward(
+    at::Tensor &attn,
     const at::Tensor &query,
     const at::Tensor &key,
     const at::optional<at::Tensor> &bias,
     const int kernel_size,
     const int dilation);
 
-std::vector<at::Tensor> na2d_qk_backward(
+void na2d_qk_backward(
+    at::Tensor &d_query,
+    at::Tensor &d_key,
+    at::optional<at::Tensor> &d_bias,
     const at::Tensor &d_attn,
     const at::Tensor &query,
     const at::Tensor &key,
-    const bool has_bias,
     const int kernel_size,
     const int dilation);
 
-at::Tensor na2d_av_forward(
+void na2d_av_forward(
+    at::Tensor &out,
     const at::Tensor &attn,
     const at::Tensor &value,
     const int kernel_size,
     const int dilation);
 
-std::vector<at::Tensor> na2d_av_backward(
+void na2d_av_backward(
+    at::Tensor &d_attn,
+    at::Tensor &d_value,
     const at::Tensor &d_out,
     const at::Tensor &attn,
     const at::Tensor &value,

--- a/csrc/include/natten/pytorch/na3d.h
+++ b/csrc/include/natten/pytorch/na3d.h
@@ -26,12 +26,12 @@
 
 #pragma once
 #include <ATen/ATen.h>
-#include <vector>
 
 namespace natten {
 namespace pytorch {
 
-at::Tensor na3d_qk_forward(
+void na3d_qk_forward(
+    at::Tensor &attn,
     const at::Tensor &query,
     const at::Tensor &key,
     const at::optional<at::Tensor> &bias,
@@ -40,17 +40,20 @@ at::Tensor na3d_qk_forward(
     const int depth_kernel_size,
     const int depth_dilation);
 
-std::vector<at::Tensor> na3d_qk_backward(
+void na3d_qk_backward(
+    at::Tensor &d_query,
+    at::Tensor &d_key,
+    at::optional<at::Tensor> &d_bias,
     const at::Tensor &d_attn,
     const at::Tensor &query,
     const at::Tensor &key,
-    const bool has_bias,
     const int kernel_size,
     const int dilation,
     const int depth_kernel_size,
     const int depth_dilation);
 
-at::Tensor na3d_av_forward(
+void na3d_av_forward(
+    at::Tensor &out,
     const at::Tensor &attn,
     const at::Tensor &value,
     const int kernel_size,
@@ -58,7 +61,9 @@ at::Tensor na3d_av_forward(
     const int depth_kernel_size,
     const int depth_dilation);
 
-std::vector<at::Tensor> na3d_av_backward(
+void na3d_av_backward(
+    at::Tensor &d_attn,
+    at::Tensor &d_value,
     const at::Tensor &d_out,
     const at::Tensor &attn,
     const at::Tensor &value,
@@ -69,4 +74,3 @@ std::vector<at::Tensor> na3d_av_backward(
 
 } // namespace pytorch
 } // namespace natten
-

--- a/csrc/src/pytorch/cpu/na1d.cpp
+++ b/csrc/src/pytorch/cpu/na1d.cpp
@@ -61,7 +61,7 @@ void na1d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int length,
@@ -74,7 +74,7 @@ void na1d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, length, dim,
             kernel_size, dilation);
 }

--- a/csrc/src/pytorch/cpu/na2d.cpp
+++ b/csrc/src/pytorch/cpu/na2d.cpp
@@ -62,7 +62,7 @@ void na2d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int height,
@@ -76,7 +76,7 @@ void na2d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, height, width, dim,
             kernel_size, dilation);
 }

--- a/csrc/src/pytorch/cpu/na3d.cpp
+++ b/csrc/src/pytorch/cpu/na3d.cpp
@@ -65,7 +65,7 @@ void na3d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int depth,
@@ -82,7 +82,7 @@ void na3d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, depth, height, width, dim,
             kernel_size, dilation, depth_kernel_size, depth_dilation);
 }

--- a/csrc/src/pytorch/cuda/na1d.cu
+++ b/csrc/src/pytorch/cuda/na1d.cu
@@ -62,7 +62,7 @@ void na1d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int length,
@@ -75,7 +75,7 @@ void na1d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, length, dim,
             kernel_size, dilation);
 }

--- a/csrc/src/pytorch/cuda/na2d.cu
+++ b/csrc/src/pytorch/cuda/na2d.cu
@@ -63,7 +63,7 @@ void na2d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int height,
@@ -77,7 +77,7 @@ void na2d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, height, width, dim,
             kernel_size, dilation);
 }

--- a/csrc/src/pytorch/cuda/na3d.cu
+++ b/csrc/src/pytorch/cuda/na3d.cu
@@ -66,7 +66,7 @@ void na3d_qk_backward(
     const at::Tensor &key,
     at::Tensor &d_query,
     at::Tensor &d_key,
-    at::Tensor &d_bias,
+    at::optional<at::Tensor> &d_bias,
     const int batch_size,
     const int heads,
     const int depth,
@@ -83,7 +83,7 @@ void na3d_qk_backward(
             static_cast<void *>(d_attn.data_ptr()),
             static_cast<void *>(d_query.data_ptr()),
             static_cast<void *>(d_key.data_ptr()),
-            d_bias.has_storage() ? static_cast<void *>(d_bias.data_ptr()) : nullptr,
+            d_bias.has_value() ? static_cast<void *>(d_bias.value().data_ptr()) : nullptr,
             batch_size, heads, depth, height, width, dim,
             kernel_size, dilation, depth_kernel_size, depth_dilation);
 }

--- a/csrc/src/pytorch/na1d.cpp
+++ b/csrc/src/pytorch/na1d.cpp
@@ -26,7 +26,6 @@
 
 #include <torch/extension.h>
 #include <ATen/ATen.h>
-#include <vector>
 #include "natten/pytorch/cpu/na1d.h"
 #ifdef NATTEN_WITH_CUDA
 #include "natten/pytorch/cuda/na1d.cuh"
@@ -37,38 +36,25 @@
 namespace natten {
 namespace pytorch {
 
-at::Tensor na1d_qk_forward(
+void na1d_qk_forward(
+    at::Tensor &attn,
     const at::Tensor &query,
     const at::Tensor &key,
     const at::optional<at::Tensor> &bias,
     const int kernel_size,
     const int dilation) {
-    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
-    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
-    CHECK_CONTIGUOUS(query);
-    CHECK_CONTIGUOUS(key);
-    TORCH_CHECK(query.scalar_type() == key.scalar_type(), "Query and key tensors must match in dtype.");
-    TORCH_CHECK(query.dim() == key.dim() && query.dim() == 4, "Expected query and key to be two 4-D tensors.");
-    TORCH_CHECK(
-            query.size(0) == key.size(0) && 
-            query.size(1) == key.size(1) && 
-            query.size(2) == key.size(2) && 
-            query.size(3) == key.size(3), "Expected query and key to be of the same shape.");
-    TORCH_CHECK(query.device().is_cuda() == key.device().is_cuda(), "Expected both query and key to be on the same device.");
+    CheckArgs(kernel_size, dilation);
+    CheckIfPropertiesMatch(query, key, attn);
+    CheckIfTensorShapesMatch<1>(query, key);
+    CheckAttnShape<1>(query, attn, kernel_size);
     if (bias.has_value()) {
-        TORCH_CHECK(query.scalar_type() == bias.value().scalar_type(), "Query, key, and bias tensors must match in dtype.");
-        TORCH_CHECK(bias.value().device().is_cuda() == key.device().is_cuda(), 
-                "Expected positional bias to be on the same device as the query and key tensors.");
-        CHECK_CONTIGUOUS(bias.value());
-        TORCH_CHECK(bias.value().size(0) == query.size(1), "Expected bias.shape[0] == query.shape[1] == heads.");
-        TORCH_CHECK(int((bias.value().size(1) + 1) / 2) == kernel_size, "Invalid bias shape.");
+        CheckBias<1>(query, bias.value(), kernel_size);
     }
     int batch_size = query.size(0);
     int heads      = query.size(1);
     int length     = query.size(2);
     int dim        = query.size(3);
-    TORCH_CHECK(kernel_size * dilation <= length, "Kernel size * dilation must be less than or equal to sequence length.");
-    auto attn = torch::empty({batch_size, heads, length, kernel_size}, query.options());
+    CheckArgsAgainstDim(length, kernel_size, dilation);
     DISPATCH_DEVICE(query.device(), na1d_qk_forward,
             query,
             key,
@@ -76,50 +62,33 @@ at::Tensor na1d_qk_forward(
             attn,
             batch_size, heads, length, dim,
             kernel_size, dilation);
-    return attn;
 }
 
 
-std::vector<at::Tensor> na1d_qk_backward(
+void na1d_qk_backward(
+    at::Tensor &d_query,
+    at::Tensor &d_key,
+    at::optional<at::Tensor> &d_bias,
     const at::Tensor &d_attn,
     const at::Tensor &query,
     const at::Tensor &key,
-    const bool has_bias,
     const int kernel_size,
     const int dilation) {
-    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
-    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
-    CHECK_CONTIGUOUS(query);
-    CHECK_CONTIGUOUS(key);
-    CHECK_CONTIGUOUS(d_attn);
-    TORCH_CHECK(query.scalar_type() == key.scalar_type(), "Query and key tensors must match in dtype.");
-    TORCH_CHECK(query.dim() == key.dim() && query.dim() == d_attn.dim() && query.dim() == 4, 
-            "Expected query, key, and d_attn to be 4-D tensors.");
-    TORCH_CHECK(
-            query.size(0) == key.size(0) && 
-            query.size(1) == key.size(1) && 
-            query.size(2) == key.size(2) && 
-            query.size(3) == key.size(3), "Expected query and key to be of the same shape.");
-    TORCH_CHECK(
-            query.size(0) == d_attn.size(0) && 
-            query.size(1) == d_attn.size(1) && 
-            query.size(2) == d_attn.size(2) && 
-            kernel_size == d_attn.size(3), "Wrong shape for d_attn.");
-    TORCH_CHECK(query.device().is_cuda() == key.device().is_cuda() && query.device().is_cuda() == d_attn.device().is_cuda(), 
-            "Expected query, key, and d_attn to be on the same device.");
+    CheckArgs(kernel_size, dilation);
+    CheckIfPropertiesMatch(query, key);
+    CheckIfPropertiesMatch(d_query, d_key, d_attn);
+    CheckIfTensorShapesMatch<1>(query, key);
+    CheckIfTensorShapesMatch<1>(d_query, d_key);
+    CheckIfTensorShapesMatch<1>(query, d_key);
+    CheckAttnShape<1>(query, d_attn, kernel_size);
+    if (d_bias.has_value()) {
+        CheckBias<1>(query, d_bias.value(), kernel_size);
+    }
     int batch_size = query.size(0);
     int heads      = query.size(1);
     int length     = query.size(2);
     int dim        = query.size(3);
-    TORCH_CHECK(kernel_size * dilation <= length, "Kernel size * dilation must be less than or equal to sequence length.");
-    auto d_query = torch::empty_like(query);
-    auto d_key   = torch::empty_like(key);
-    at::Tensor d_bias;
-    if (has_bias) {
-        auto rpb_dtype = query.scalar_type() == torch::kFloat64 ? query.scalar_type() : torch::kFloat32;
-        auto options = query.options().dtype(rpb_dtype);
-        d_bias = torch::zeros({heads, 2 * kernel_size - 1}, options);
-    }
+    CheckArgsAgainstDim(length, kernel_size, dilation);
     DISPATCH_DEVICE(d_attn.device(), na1d_qk_backward,
             d_attn,
             query,
@@ -129,74 +98,51 @@ std::vector<at::Tensor> na1d_qk_backward(
             d_bias,
             batch_size, heads, length, dim,
             kernel_size, dilation);
-    return {d_query, d_key, d_bias};
 }
 
-at::Tensor na1d_av_forward(
+void na1d_av_forward(
+    at::Tensor &out,
     const at::Tensor &attn,
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
-    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
-    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
-    CHECK_CONTIGUOUS(attn);
-    CHECK_CONTIGUOUS(value);
-    TORCH_CHECK(attn.scalar_type() == value.scalar_type(), "Attention and value tensors must match in dtype.");
-    TORCH_CHECK(attn.dim() == value.dim() && attn.dim() == 4, "Expected attention and value to be two 4-D tensors.");
-    TORCH_CHECK(
-            attn.size(0) == value.size(0) && 
-            attn.size(1) == value.size(1) && 
-            attn.size(2) == value.size(2), "Expected attention and value to match in batch size, heads, and length.");
-    TORCH_CHECK(kernel_size == attn.size(3), "Attention weights per token do not match kernel size.");
-    TORCH_CHECK(attn.device().is_cuda() == value.device().is_cuda(), "Expected both attention and value to be on the same device.");
+    CheckArgs(kernel_size, dilation);
+    CheckIfPropertiesMatch(out, value, attn);
+    CheckIfTensorShapesMatch<1>(out, value);
+    CheckAttnShape<1>(value, attn, kernel_size);
     int batch_size = value.size(0);
     int heads      = value.size(1);
     int length     = value.size(2);
     int dim        = value.size(3);
-    TORCH_CHECK(kernel_size * dilation <= length, "Kernel size * dilation must be less than or equal to sequence length.");
-    auto output = torch::empty_like(value);
+    CheckArgsAgainstDim(length, kernel_size, dilation);
     DISPATCH_DEVICE(attn.device(), na1d_av_forward,
             attn,
             value,
-            output,
+            out,
             batch_size, heads, length, dim,
             kernel_size, dilation);
-    return output;
 }
 
-std::vector<at::Tensor> na1d_av_backward(
+void na1d_av_backward(
+    at::Tensor &d_attn,
+    at::Tensor &d_value,
     const at::Tensor &d_out,
     const at::Tensor &attn,
     const at::Tensor &value,
     const int kernel_size,
     const int dilation) {
-    TORCH_CHECK(kernel_size > 1 && kernel_size % 2 == 1, "Kernel size must be an odd number greater than 1.");
-    TORCH_CHECK(dilation >= 1, "Dilation must be a nonnegative integer.");
-    CHECK_CONTIGUOUS(attn);
-    CHECK_CONTIGUOUS(value);
-    CHECK_CONTIGUOUS(d_out);
-    TORCH_CHECK(d_out.scalar_type() == value.scalar_type(), "d_out and value tensors must match in dtype.");
-    TORCH_CHECK(d_out.dim() == value.dim() && d_out.dim() == attn.dim() && d_out.dim() == 4, 
-            "Expected d_out, value, and attn to be 4-D tensors.");
-    TORCH_CHECK(
-            d_out.size(0) == value.size(0) && 
-            d_out.size(1) == value.size(1) && 
-            d_out.size(2) == value.size(2) && 
-            d_out.size(3) == value.size(3), "Expected d_out and value to be of the same shape.");
-    TORCH_CHECK(
-            d_out.size(0) == attn.size(0) && 
-            d_out.size(1) == attn.size(1) && 
-            d_out.size(2) == attn.size(2) && 
-            kernel_size == attn.size(3), "Wrong shape for attn.");
-    TORCH_CHECK(d_out.device().is_cuda() == value.device().is_cuda() && d_out.device().is_cuda() == attn.device().is_cuda(), 
-            "Expected d_out, value, and attn to be on the same device.");
-    int batch_size = d_out.size(0);
-    int heads      = d_out.size(1);
-    int length     = d_out.size(2);
-    int dim        = d_out.size(3);
-    TORCH_CHECK(kernel_size * dilation <= length, "Kernel size * dilation must be less than or equal to sequence length.");
-    auto d_attn  = torch::empty_like(attn);
-    auto d_value = torch::empty_like(value);
+    CheckArgs(kernel_size, dilation);
+    CheckIfPropertiesMatch(attn, value);
+    CheckIfPropertiesMatch(d_attn, d_value, d_out);
+    CheckIfTensorShapesMatch<1>(value, d_value);
+    CheckIfTensorShapesMatch<1>(attn, d_attn);
+    CheckIfTensorShapesMatch<1>(value, d_out);
+    CheckAttnShape<1>(value, attn, kernel_size);
+    int batch_size = value.size(0);
+    int heads      = value.size(1);
+    int length     = value.size(2);
+    int dim        = value.size(3);
+    CheckArgsAgainstDim(length, kernel_size, dilation);
     DISPATCH_DEVICE(attn.device(), na1d_av_backward,
             d_out,
             attn,
@@ -205,7 +151,6 @@ std::vector<at::Tensor> na1d_av_backward(
             d_value,
             batch_size, heads, length, dim,
             kernel_size, dilation);
-    return {d_attn, d_value};
 }
 
 } // namespace pytorch

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -21,6 +21,7 @@
 #
 #################################################################################################
 import torch
+from torch import Tensor
 from torch.autograd import Function
 from torch.cuda.amp import custom_bwd, custom_fwd
 
@@ -34,6 +35,10 @@ except ImportError:
         f" correct torch build: "
         + f"shi-labs.com/natten"
     )
+
+from .nested import (na1d_av_nested, na1d_qk_nested, na2d_av_nested,
+                     na2d_qk_nested, na3d_av_nested, na3d_qk_nested)
+from .utils import make_attn_tensor_from_input
 
 
 def has_cuda():
@@ -82,11 +87,13 @@ class NeighborhoodAttention1DQKAutogradFunction(Function):
     def forward(ctx, query, key, rpb, kernel_size, dilation):
         query = query.contiguous()
         key = key.contiguous()
-        attn = _C.na1d_qk_forward(query, key, rpb, kernel_size, dilation)
-        ctx.save_for_backward(query, key)
+        if rpb is not None:
+            rpb = rpb.to(key.dtype)
+        attn = make_attn_tensor_from_input(query, kernel_size)
+        _C.na1d_qk_forward(attn, query, key, rpb, kernel_size, dilation)
+        ctx.save_for_backward(query, key, rpb)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
-        ctx.bias = rpb is not None
         return attn
 
     @staticmethod
@@ -101,25 +108,33 @@ class NeighborhoodAttention1DQKAutogradFunction(Function):
                 "Positional biases are currently not supported "
                 "in forward mode autodiff."
             )
-        query_p, key_p = ctx.to_save
+        query_p, key_p, _ = ctx.to_save
         query_t = query_t.contiguous()
         key_t = key_t.contiguous()
-        return _C.na1d_qk_forward(
-            query_t, key_p, None, ctx.kernel_size, ctx.dilation
-        ) + _C.na1d_qk_forward(query_p, key_t, None, ctx.kernel_size, ctx.dilation)
+        attn_0 = make_attn_tensor_from_input(query_t, ctx.kernel_size)
+        attn_1 = torch.empty_like(attn_0)
+        _C.na1d_qk_forward(attn_0, query_t, key_p, None, ctx.kernel_size, ctx.dilation)
+        _C.na1d_qk_forward(attn_1, query_p, key_t, None, ctx.kernel_size, ctx.dilation)
+        return attn_0 + attn_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na1d_qk_backward(
+        query, key, rpb = ctx.saved_tensors
+        d_query = torch.empty_like(query)
+        d_key = torch.empty_like(key)
+        # dRPB has to be zero filled
+        d_rpb = None if rpb is None else torch.zeros_like(rpb)
+        _C.na1d_qk_backward(
+            d_query,
+            d_key,
+            d_rpb,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
-            ctx.bias,
+            query,
+            key,
             ctx.kernel_size,
             ctx.dilation,
         )
-        d_query, d_key, d_rpb = outputs
         return d_query, d_key, d_rpb, None, None
 
 
@@ -129,7 +144,8 @@ class NeighborhoodAttention1DAVAutogradFunction(Function):
     def forward(ctx, attn, value, kernel_size, dilation):
         attn = attn.contiguous()
         value = value.contiguous()
-        out = _C.na1d_av_forward(attn, value, kernel_size, dilation)
+        out = torch.empty_like(value)
+        _C.na1d_av_forward(out, attn, value, kernel_size, dilation)
         ctx.save_for_backward(attn, value)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
@@ -145,21 +161,27 @@ class NeighborhoodAttention1DAVAutogradFunction(Function):
         attn_p, value_p = ctx.to_save
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
-        return _C.na1d_av_forward(
-            attn_t, value_p, ctx.kernel_size, ctx.dilation
-        ) + _C.na1d_av_forward(attn_p, value_t, ctx.kernel_size, ctx.dilation)
+        out_0 = torch.empty_like(value_p)
+        out_1 = torch.empty_like(out_0)
+        _C.na1d_av_forward(out_0, attn_t, value_p, ctx.kernel_size, ctx.dilation)
+        _C.na1d_av_forward(out_1, attn_p, value_t, ctx.kernel_size, ctx.dilation)
+        return out_0 + out_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na1d_av_backward(
+        attn, value = ctx.saved_tensors
+        d_attn = torch.empty_like(attn)
+        d_value = torch.empty_like(value)
+        _C.na1d_av_backward(
+            d_attn,
+            d_value,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
+            attn,
+            value,
             ctx.kernel_size,
             ctx.dilation,
         )
-        d_attn, d_value = outputs
         return d_attn, d_value, None, None
 
 
@@ -171,11 +193,11 @@ class NeighborhoodAttention2DQKAutogradFunction(Function):
         key = key.contiguous()
         if rpb is not None:
             rpb = rpb.to(key.dtype)
-        attn = _C.na2d_qk_forward(query, key, rpb, kernel_size, dilation)
-        ctx.save_for_backward(query, key)
+        attn = make_attn_tensor_from_input(query, kernel_size**2)
+        _C.na2d_qk_forward(attn, query, key, rpb, kernel_size, dilation)
+        ctx.save_for_backward(query, key, rpb)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
-        ctx.bias = rpb is not None
         return attn
 
     @staticmethod
@@ -190,25 +212,33 @@ class NeighborhoodAttention2DQKAutogradFunction(Function):
                 "Positional biases are currently not supported "
                 "in forward mode autodiff."
             )
-        query_p, key_p = ctx.to_save
+        query_p, key_p, _ = ctx.to_save
         query_t = query_t.contiguous()
         key_t = key_t.contiguous()
-        return _C.na2d_qk_forward(
-            query_t, key_p, None, ctx.kernel_size, ctx.dilation
-        ) + _C.na2d_qk_forward(query_p, key_t, None, ctx.kernel_size, ctx.dilation)
+        attn_0 = make_attn_tensor_from_input(query_t, ctx.kernel_size**2)
+        attn_1 = torch.empty_like(attn_0)
+        _C.na2d_qk_forward(attn_0, query_t, key_p, None, ctx.kernel_size, ctx.dilation)
+        _C.na2d_qk_forward(attn_1, query_p, key_t, None, ctx.kernel_size, ctx.dilation)
+        return attn_0 + attn_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na2d_qk_backward(
+        query, key, rpb = ctx.saved_tensors
+        d_query = torch.empty_like(query)
+        d_key = torch.empty_like(key)
+        # dRPB has to be zero filled
+        d_rpb = None if rpb is None else torch.zeros_like(rpb)
+        _C.na2d_qk_backward(
+            d_query,
+            d_key,
+            d_rpb,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
-            ctx.bias,
+            query,
+            key,
             ctx.kernel_size,
             ctx.dilation,
         )
-        d_query, d_key, d_rpb = outputs
         return d_query, d_key, d_rpb, None, None
 
 
@@ -216,9 +246,10 @@ class NeighborhoodAttention2DAVAutogradFunction(Function):
     @staticmethod
     @custom_fwd
     def forward(ctx, attn, value, kernel_size, dilation):
-        attn = attn.contiguous().to(value.dtype)
+        attn = attn.contiguous()
         value = value.contiguous()
-        out = _C.na2d_av_forward(attn, value, kernel_size, dilation)
+        out = torch.empty_like(value)
+        _C.na2d_av_forward(out, attn, value, kernel_size, dilation)
         ctx.save_for_backward(attn, value)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
@@ -234,21 +265,27 @@ class NeighborhoodAttention2DAVAutogradFunction(Function):
         attn_p, value_p = ctx.to_save
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
-        return _C.na2d_av_forward(
-            attn_t, value_p, ctx.kernel_size, ctx.dilation
-        ) + _C.na2d_av_forward(attn_p, value_t, ctx.kernel_size, ctx.dilation)
+        out_0 = torch.empty_like(value_p)
+        out_1 = torch.empty_like(out_0)
+        _C.na2d_av_forward(out_0, attn_t, value_p, ctx.kernel_size, ctx.dilation)
+        _C.na2d_av_forward(out_1, attn_p, value_t, ctx.kernel_size, ctx.dilation)
+        return out_0 + out_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na2d_av_backward(
+        attn, value = ctx.saved_tensors
+        d_attn = torch.empty_like(attn)
+        d_value = torch.empty_like(value)
+        _C.na2d_av_backward(
+            d_attn,
+            d_value,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
+            attn,
+            value,
             ctx.kernel_size,
             ctx.dilation,
         )
-        d_attn, d_value = outputs
         return d_attn, d_value, None, None
 
 
@@ -258,15 +295,19 @@ class NeighborhoodAttention3DQKAutogradFunction(Function):
     def forward(ctx, query, key, rpb, kernel_size_d, kernel_size, dilation_d, dilation):
         query = query.contiguous()
         key = key.contiguous()
-        attn = _C.na3d_qk_forward(
-            query, key, rpb, kernel_size, dilation, kernel_size_d, dilation_d
+        if rpb is not None:
+            rpb = rpb.to(key.dtype)
+        attn = make_attn_tensor_from_input(
+            query, kernel_size * kernel_size * kernel_size_d
         )
-        ctx.save_for_backward(query, key)
+        _C.na3d_qk_forward(
+            attn, query, key, rpb, kernel_size, dilation, kernel_size_d, dilation_d
+        )
+        ctx.save_for_backward(query, key, rpb)
         ctx.kernel_size_d = kernel_size_d
         ctx.kernel_size = kernel_size
         ctx.dilation_d = dilation_d
         ctx.dilation = dilation
-        ctx.bias = rpb is not None
         return attn
 
     @staticmethod
@@ -281,10 +322,15 @@ class NeighborhoodAttention3DQKAutogradFunction(Function):
                 "Positional biases are currently not supported "
                 "in forward mode autodiff."
             )
-        query_p, key_p = ctx.to_save
+        query_p, key_p, _ = ctx.to_save
         query_t = query_t.contiguous()
         key_t = key_t.contiguous()
-        return _C.na3d_qk_forward(
+        attn_0 = make_attn_tensor_from_input(
+            query_t, ctx.kernel_size * ctx.kernel_size * ctx.kernel_size_d
+        )
+        attn_1 = torch.empty_like(attn_0)
+        _C.na3d_qk_forward(
+            attn_0,
             query_t,
             key_p,
             None,
@@ -292,7 +338,9 @@ class NeighborhoodAttention3DQKAutogradFunction(Function):
             ctx.dilation,
             ctx.kernel_size_d,
             ctx.dilation_d,
-        ) + _C.na3d_qk_forward(
+        )
+        _C.na3d_qk_forward(
+            attn_1,
             query_p,
             key_t,
             None,
@@ -301,21 +349,28 @@ class NeighborhoodAttention3DQKAutogradFunction(Function):
             ctx.kernel_size_d,
             ctx.dilation_d,
         )
+        return attn_0 + attn_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na3d_qk_backward(
+        query, key, rpb = ctx.saved_tensors
+        d_query = torch.empty_like(query)
+        d_key = torch.empty_like(key)
+        # dRPB has to be zero filled
+        d_rpb = None if rpb is None else torch.zeros_like(rpb)
+        _C.na3d_qk_backward(
+            d_query,
+            d_key,
+            d_rpb,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
-            ctx.bias,
+            query,
+            key,
             ctx.kernel_size,
             ctx.dilation,
             ctx.kernel_size_d,
             ctx.dilation_d,
         )
-        d_query, d_key, d_rpb = outputs
         return d_query, d_key, d_rpb, None, None, None, None
 
 
@@ -325,8 +380,9 @@ class NeighborhoodAttention3DAVAutogradFunction(Function):
     def forward(ctx, attn, value, kernel_size_d, kernel_size, dilation_d, dilation):
         attn = attn.contiguous()
         value = value.contiguous()
-        out = _C.na3d_av_forward(
-            attn, value, kernel_size, dilation, kernel_size_d, dilation_d
+        out = torch.empty_like(value)
+        _C.na3d_av_forward(
+            out, attn, value, kernel_size, dilation, kernel_size_d, dilation_d
         )
         ctx.save_for_backward(attn, value)
         ctx.kernel_size_d = kernel_size_d
@@ -345,14 +401,19 @@ class NeighborhoodAttention3DAVAutogradFunction(Function):
         attn_p, value_p = ctx.to_save
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
-        return _C.na3d_av_forward(
+        out_0 = torch.empty_like(value_p)
+        out_1 = torch.empty_like(out_0)
+        _C.na3d_av_forward(
+            out_0,
             attn_t,
             value_p,
             ctx.kernel_size,
             ctx.dilation,
             ctx.kernel_size_d,
             ctx.dilation_d,
-        ) + _C.na3d_av_forward(
+        )
+        _C.na3d_av_forward(
+            out_1,
             attn_p,
             value_t,
             ctx.kernel_size,
@@ -360,72 +421,101 @@ class NeighborhoodAttention3DAVAutogradFunction(Function):
             ctx.kernel_size_d,
             ctx.dilation_d,
         )
+        return out_0 + out_1
 
     @staticmethod
     @custom_bwd
     def backward(ctx, grad_out):
-        outputs = _C.na3d_av_backward(
+        attn, value = ctx.saved_tensors
+        d_attn = torch.empty_like(attn)
+        d_value = torch.empty_like(value)
+        _C.na3d_av_backward(
+            d_attn,
+            d_value,
             grad_out.contiguous(),
-            ctx.saved_tensors[0],
-            ctx.saved_tensors[1],
+            attn,
+            value,
             ctx.kernel_size,
             ctx.dilation,
             ctx.kernel_size_d,
             ctx.dilation_d,
         )
-        d_attn, d_value = outputs
         return d_attn, d_value, None, None, None, None
 
 
 def natten1dqkrpb(query, key, rpb, kernel_size, dilation):
+    if query.is_nested or key.is_nested:
+        return na1d_qk_nested(query, key, rpb, kernel_size, dilation)
     return NeighborhoodAttention1DQKAutogradFunction.apply(
         query, key, rpb, kernel_size, dilation
     )
 
 
 def natten1dqk(query, key, kernel_size, dilation):
+    if query.is_nested or key.is_nested:
+        return na1d_qk_nested(query, key, None, kernel_size, dilation)
     return NeighborhoodAttention1DQKAutogradFunction.apply(
         query, key, None, kernel_size, dilation
     )
 
 
 def natten1dav(attn, value, kernel_size, dilation):
+    if attn.is_nested or value.is_nested:
+        return na1d_av_nested(attn, value, kernel_size, dilation)
     return NeighborhoodAttention1DAVAutogradFunction.apply(
         attn, value, kernel_size, dilation
     )
 
 
 def natten2dqkrpb(query, key, rpb, kernel_size, dilation):
+    if query.is_nested or key.is_nested:
+        return na2d_qk_nested(query, key, rpb, kernel_size, dilation)
     return NeighborhoodAttention2DQKAutogradFunction.apply(
         query, key, rpb, kernel_size, dilation
     )
 
 
 def natten2dqk(query, key, kernel_size, dilation):
+    if query.is_nested or key.is_nested:
+        return na2d_qk_nested(query, key, None, kernel_size, dilation)
     return NeighborhoodAttention2DQKAutogradFunction.apply(
         query, key, None, kernel_size, dilation
     )
 
 
 def natten2dav(attn, value, kernel_size, dilation):
+    if attn.is_nested or value.is_nested:
+        return na2d_av_nested(attn, value, kernel_size, dilation)
     return NeighborhoodAttention2DAVAutogradFunction.apply(
         attn, value, kernel_size, dilation
     )
 
 
 def natten3dqkrpb(query, key, rpb, kernel_size_d, kernel_size, dilation_d, dilation):
+    if query.is_nested or key.is_nested:
+        return na3d_qk_nested(
+            query, key, rpb, kernel_size_d, kernel_size, dilation_d, dilation
+        )
     return NeighborhoodAttention3DQKAutogradFunction.apply(
         query, key, rpb, kernel_size_d, kernel_size, dilation_d, dilation
     )
 
 
 def natten3dqk(query, key, kernel_size_d, kernel_size, dilation_d, dilation):
+    if query.is_nested or key.is_nested:
+        return na3d_qk_nested(
+            query, key, None, kernel_size_d, kernel_size, dilation_d, dilation
+        )
     return NeighborhoodAttention3DQKAutogradFunction.apply(
         query, key, None, kernel_size_d, kernel_size, dilation_d, dilation
     )
 
 
 def natten3dav(attn, value, kernel_size_d, kernel_size, dilation_d, dilation):
+    if attn.is_nested or value.is_nested:
+        return na3d_av_nested(
+            attn, value, kernel_size_d, kernel_size, dilation_d, dilation
+        )
     return NeighborhoodAttention3DAVAutogradFunction.apply(
         attn, value, kernel_size_d, kernel_size, dilation_d, dilation
     )

--- a/src/natten/nested.py
+++ b/src/natten/nested.py
@@ -1,0 +1,192 @@
+#################################################################################################
+# Copyright (c) 2023 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+from typing import Optional
+
+import torch
+from torch import Tensor
+from torch.autograd import Function
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+try:
+    from natten import _C
+except ImportError:
+    raise ImportError(
+        f"Failed to import NATTEN's CPP backend. "
+        + f"This could be due to an invalid/incomplete install. "
+        + f"Please uninstall NATTEN (pip uninstall natten) and re-install with the"
+        f" correct torch build: "
+        + f"shi-labs.com/natten"
+    )
+
+from .utils import make_attn_tensor_from_input
+
+
+def na1d_qk_nested(
+    query: Tensor, key: Tensor, rpb: Optional[Tensor], kernel_size: int, dilation: int
+) -> Tensor:
+    if not query.is_nested or not key.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not query.is_leaf or not key.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if query.requires_grad or key.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+    if rpb is not None and rpb.is_nested:
+        raise ValueError("Positional biases cannot be nested.")
+
+    if rpb is not None:
+        rpb = rpb.contiguous().to(key.dtype)
+
+    if query.size(0) != key.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    attn = torch.nested.nested_tensor(
+        [make_attn_tensor_from_input(q, kernel_size) for q in query]
+    )
+    for q, k, a in zip(query, key, attn):
+        _C.na1d_qk_forward(a, q, k, rpb, kernel_size, dilation)
+
+    return attn
+
+
+def na1d_av_nested(attn: Tensor, value: Tensor, kernel_size: int, dilation: int):
+    if not attn.is_nested or not value.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not attn.is_leaf or not value.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if attn.requires_grad or value.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+
+    if attn.size(0) != value.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    out = torch.empty_like(value)
+    for a, v, o in zip(attn, value, out):
+        _C.na1d_av_forward(o, a, v, kernel_size, dilation)
+
+    return out
+
+
+def na2d_qk_nested(
+    query: Tensor, key: Tensor, rpb: Optional[Tensor], kernel_size: int, dilation: int
+) -> Tensor:
+    if not query.is_nested or not key.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not query.is_leaf or not key.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if query.requires_grad or key.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+    if rpb is not None and rpb.is_nested:
+        raise ValueError("Positional biases cannot be nested.")
+
+    if rpb is not None:
+        rpb = rpb.contiguous().to(key.dtype)
+
+    if query.size(0) != key.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    attn = torch.nested.nested_tensor(
+        [make_attn_tensor_from_input(q, kernel_size**2) for q in query]
+    )
+    for q, k, a in zip(query, key, attn):
+        _C.na2d_qk_forward(a, q, k, rpb, kernel_size, dilation)
+
+    return attn
+
+
+def na2d_av_nested(attn: Tensor, value: Tensor, kernel_size: int, dilation: int):
+    if not attn.is_nested or not value.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not attn.is_leaf or not value.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if attn.requires_grad or value.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+
+    if attn.size(0) != value.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    out = torch.empty_like(value)
+    for a, v, o in zip(attn, value, out):
+        _C.na2d_av_forward(o, a, v, kernel_size, dilation)
+
+    return out
+
+
+def na3d_qk_nested(
+    query: Tensor,
+    key: Tensor,
+    rpb: Optional[Tensor],
+    kernel_size_d: int,
+    kernel_size: int,
+    dilation_d: int,
+    dilation: int,
+) -> Tensor:
+    if not query.is_nested or not key.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not query.is_leaf or not key.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if query.requires_grad or key.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+    if rpb is not None and rpb.is_nested:
+        raise ValueError("Positional biases cannot be nested.")
+
+    if rpb is not None:
+        rpb = rpb.contiguous().to(key.dtype)
+
+    if query.size(0) != key.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    attn = torch.nested.nested_tensor([
+        make_attn_tensor_from_input(q, kernel_size * kernel_size * kernel_size_d)
+        for q in query
+    ])
+    for q, k, a in zip(query, key, attn):
+        _C.na3d_qk_forward(
+            a, q, k, rpb, kernel_size, dilation, kernel_size_d, dilation_d
+        )
+
+    return attn
+
+
+def na3d_av_nested(
+    attn: Tensor,
+    value: Tensor,
+    kernel_size_d: int,
+    kernel_size: int,
+    dilation_d: int,
+    dilation: int,
+):
+    if not attn.is_nested or not value.is_nested:
+        raise ValueError("Expected all inputs to be nested.")
+    if not attn.is_leaf or not value.is_leaf:
+        raise ValueError("Only one level of nested tensors is supported at the moment.")
+    if attn.requires_grad or value.requires_grad:
+        raise ValueError("Autograd is not supported for nested tensors.")
+
+    if attn.size(0) != value.size(0):
+        raise ValueError("Got nested inputs, but they don't match in size.")
+
+    out = torch.empty_like(value)
+    for a, v, o in zip(attn, value, out):
+        _C.na3d_av_forward(o, a, v, kernel_size, dilation, kernel_size_d, dilation_d)
+
+    return out

--- a/src/natten/utils.py
+++ b/src/natten/utils.py
@@ -1,0 +1,35 @@
+#################################################################################################
+# Copyright (c) 2023 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+
+import torch
+from torch import Tensor
+
+
+def make_attn_tensor_from_input(input_tensor: Tensor, attention_dim: int) -> Tensor:
+    shape = [x for x in input_tensor.shape[:-1]] + [attention_dim]
+    return torch.empty(
+        shape,
+        device=input_tensor.device,
+        dtype=input_tensor.dtype,
+        requires_grad=input_tensor.requires_grad,
+    )

--- a/tests/test_na2d.py
+++ b/tests/test_na2d.py
@@ -34,6 +34,7 @@ from natten import (disable_gemm_na, disable_tf32, disable_tiled_na,
                     has_cuda, has_gemm, has_half)
 from natten.functional import natten2dav, natten2dqkrpb
 
+SKIP_NESTED_TESTS = [int(x) for x in torch.__version__.split(".")[:2]] < [2, 1]
 HAS_CUDA = torch.cuda.is_available() and (CUDA_HOME is not None) and has_cuda()
 HAS_GEMM = has_gemm()
 HAS_HALF = has_half()
@@ -508,6 +509,76 @@ class NA2DTests(unittest.TestCase):
         self._test_fwad(
             B=1, H=1, X=7, Y=6, D=8, kernel_size=3, dilation=2, device="cuda"
         )
+
+    def _test_nested_qk_forward(self, dtype, device):
+        torch.manual_seed(42)
+        kernel_size, dilation = 7, 2
+        kwargs = {"dtype": dtype, "device": device, "requires_grad": False}
+        query = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 14, 16, 16),
+                torch.randn(2, 8, 16, 18, 32),
+                torch.randn(4, 1, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        key = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 14, 16, 16),
+                torch.randn(2, 8, 16, 18, 32),
+                torch.randn(4, 1, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        out_nested = natten2dqkrpb(query, key, None, kernel_size, dilation)
+        out_ref = []
+        for q, k in zip(query, key):
+            out_ref.append(natten2dqkrpb(q, k, None, kernel_size, dilation))
+
+        for o, o_ref in zip(out_nested, out_ref):
+            torch.testing.assert_close(o, o_ref, atol=1e-6, rtol=0)
+
+    def _test_nested_av_forward(self, dtype, device):
+        torch.manual_seed(42)
+        kernel_size, dilation = 7, 2
+        kwargs = {"dtype": dtype, "device": device, "requires_grad": False}
+        attn = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 14, 16, kernel_size**2),
+                torch.randn(2, 8, 16, 18, kernel_size**2),
+                torch.randn(4, 1, 32, 20, kernel_size**2),
+            ],
+            **kwargs,
+        )
+        value = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 14, 16, 16),
+                torch.randn(2, 8, 16, 18, 32),
+                torch.randn(4, 1, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        out_nested = natten2dav(attn, value, kernel_size, dilation)
+        out_ref = []
+        for a, v in zip(attn, value):
+            out_ref.append(natten2dav(a, v, kernel_size, dilation))
+
+        for o, o_ref in zip(out_nested, out_ref):
+            torch.testing.assert_close(o, o_ref, atol=1e-6, rtol=0)
+
+    def test_nested_forward_cpu(self):
+        if SKIP_NESTED_TESTS:
+            self.skipTest("Nested tensors are only supported with torch >= 2.1.")
+        self._test_nested_qk_forward(dtype=torch.float32, device="cpu")
+        self._test_nested_av_forward(dtype=torch.float32, device="cpu")
+
+    def test_nested_forward_cuda(self):
+        if SKIP_NESTED_TESTS:
+            self.skipTest("Nested tensors are only supported with torch >= 2.1.")
+        if not HAS_CUDA:
+            self.skipTest("NATTEN not compiled with CUDA.")
+        self._test_nested_qk_forward(dtype=torch.float16, device="cuda")
+        self._test_nested_av_forward(dtype=torch.float16, device="cuda")
 
 
 if __name__ == "__main__":

--- a/tests/test_na3d.py
+++ b/tests/test_na3d.py
@@ -32,6 +32,7 @@ from torch.utils.cpp_extension import CUDA_HOME
 from natten import has_bfloat, has_cuda, has_half
 from natten.functional import natten3dav, natten3dqkrpb
 
+SKIP_NESTED_TESTS = [int(x) for x in torch.__version__.split(".")[:2]] < [2, 1]
 HAS_CUDA = torch.cuda.is_available() and (CUDA_HOME is not None) and has_cuda()
 HAS_HALF = has_half()
 HAS_BFLOAT = has_bfloat()
@@ -350,6 +351,88 @@ class NA3DTests(unittest.TestCase):
             dilation=1,
             device="cuda",
         )
+
+    def _test_nested_qk_forward(self, dtype, device):
+        torch.manual_seed(42)
+        kernel_size, dilation = 7, 2
+        kernel_size_d, dilation_d = 3, 3
+        kwargs = {"dtype": dtype, "device": device, "requires_grad": False}
+        query = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 9, 14, 16, 16),
+                torch.randn(2, 8, 9, 16, 18, 32),
+                torch.randn(4, 1, 9, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        key = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 9, 14, 16, 16),
+                torch.randn(2, 8, 9, 16, 18, 32),
+                torch.randn(4, 1, 9, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        out_nested = natten3dqkrpb(
+            query, key, None, kernel_size_d, kernel_size, dilation_d, dilation
+        )
+        out_ref = []
+        for q, k in zip(query, key):
+            out_ref.append(
+                natten3dqkrpb(
+                    q, k, None, kernel_size_d, kernel_size, dilation_d, dilation
+                )
+            )
+
+        for o, o_ref in zip(out_nested, out_ref):
+            torch.testing.assert_close(o, o_ref, atol=1e-6, rtol=0)
+
+    def _test_nested_av_forward(self, dtype, device):
+        torch.manual_seed(42)
+        kernel_size, dilation = 7, 2
+        kernel_size_d, dilation_d = 3, 3
+        kwargs = {"dtype": dtype, "device": device, "requires_grad": False}
+        attn = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 9, 14, 16, kernel_size_d * kernel_size * kernel_size),
+                torch.randn(2, 8, 9, 16, 18, kernel_size_d * kernel_size * kernel_size),
+                torch.randn(4, 1, 9, 32, 20, kernel_size_d * kernel_size * kernel_size),
+            ],
+            **kwargs,
+        )
+        value = torch.nested.nested_tensor(
+            [
+                torch.randn(1, 2, 9, 14, 16, 16),
+                torch.randn(2, 8, 9, 16, 18, 32),
+                torch.randn(4, 1, 9, 32, 20, 16),
+            ],
+            **kwargs,
+        )
+        out_nested = natten3dav(
+            attn, value, kernel_size_d, kernel_size, dilation_d, dilation
+        )
+        out_ref = []
+        for a, v in zip(attn, value):
+            out_ref.append(
+                natten3dav(a, v, kernel_size_d, kernel_size, dilation_d, dilation)
+            )
+
+        for o, o_ref in zip(out_nested, out_ref):
+            torch.testing.assert_close(o, o_ref, atol=1e-6, rtol=0)
+
+    def test_nested_forward_cpu(self):
+        if SKIP_NESTED_TESTS:
+            self.skipTest("Nested tensors are only supported with torch >= 2.1.")
+        self._test_nested_qk_forward(dtype=torch.float32, device="cpu")
+        self._test_nested_av_forward(dtype=torch.float32, device="cpu")
+
+    def test_nested_forward_cuda(self):
+        if SKIP_NESTED_TESTS:
+            self.skipTest("Nested tensors are only supported with torch >= 2.1.")
+        if not HAS_CUDA:
+            self.skipTest("NATTEN not compiled with CUDA.")
+        self._test_nested_qk_forward(dtype=torch.float16, device="cuda")
+        self._test_nested_av_forward(dtype=torch.float16, device="cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Adds basic support for single-level nested tensor inference
  * Partially addresses #72 ;
  * Backward pass / Forward mode AD are not supported; torch autograd api does not allow them yet. Will open an issue for this.
* C++ API now expects output tensor refs instead of creating its own.
  * This will finally fix #13 .