### PR TITLE
Extend unit tests and fix minor bug in naive PN kernels

### DIFF
--- a/csrc/include/natten/cuda/naive/pointwise_neighborhood_1d.cuh
+++ b/csrc/include/natten/cuda/naive/pointwise_neighborhood_1d.cuh
@@ -130,7 +130,7 @@ struct PointwiseNeighborhood1DBase {
     int KERNELTHREADS = min(CUDA_NUM_THREADS, kernel_size);
     int TOKENTHREADS = min(CUDA_NUM_THREADS / KERNELTHREADS, length);
     int BATCHTHREADS =
-        max(1, CUDA_NUM_THREADS / (TOKENTHREADS * KERNELTHREADS));
+        min(64, max(1, CUDA_NUM_THREADS / (TOKENTHREADS * KERNELTHREADS)));
     dim3 grid(
         (length + TOKENTHREADS - 1) / TOKENTHREADS,
         (kernel_size + KERNELTHREADS - 1) / KERNELTHREADS,

--- a/csrc/include/natten/cuda/naive/pointwise_neighborhood_3d.cuh
+++ b/csrc/include/natten/cuda/naive/pointwise_neighborhood_3d.cuh
@@ -171,7 +171,7 @@ struct PointwiseNeighborhood3DBase {
         min(CUDA_NUM_THREADS, attention_span /* == kernel_size^3 */);
     int PIXELTHREADS = min(int(CUDA_NUM_THREADS / KERNELTHREADS), spatial_size);
     int BATCHTHREADS =
-        max(1, CUDA_NUM_THREADS / (PIXELTHREADS * KERNELTHREADS));
+        min(64, max(1, CUDA_NUM_THREADS / (PIXELTHREADS * KERNELTHREADS)));
     dim3 grid(
         (spatial_size + PIXELTHREADS - 1) / PIXELTHREADS,
         (attention_span + KERNELTHREADS - 1) / KERNELTHREADS,

--- a/csrc/include/natten/cuda/naive/tiled/base.cuh
+++ b/csrc/include/natten/cuda/naive/tiled/base.cuh
@@ -148,7 +148,7 @@ struct PointwiseNeighborhood2DBase {
         min(CUDA_NUM_THREADS, attention_span /* == kernel_size^2 */);
     int PIXELTHREADS = min(int(CUDA_NUM_THREADS / KERNELTHREADS), spatial_size);
     int BATCHTHREADS =
-        max(1, CUDA_NUM_THREADS / (PIXELTHREADS * KERNELTHREADS));
+        min(64, max(1, CUDA_NUM_THREADS / (PIXELTHREADS * KERNELTHREADS)));
     dim3 grid(
         (spatial_size + PIXELTHREADS - 1) / PIXELTHREADS,
         (attention_span + KERNELTHREADS - 1) / KERNELTHREADS,


### PR DESCRIPTION
Unit tests were extended to check new features (#82) in more detail. Forward pass is also tested against a reference BMM SA.

PN kernels were also not capping the number of threads in the z axis, which should be capped at 64. This might cause launch failures for very small problems, but mostly in NA1D.

#32 can be closed now; #85 switched to int64 indexing, and this PR adds unit tests that cover the case in #32.