### PR TITLE
Allow broadcasting cross attention tokens across batch

### DIFF
--- a/tests/test_na2d.py
+++ b/tests/test_na2d.py
@@ -663,6 +663,7 @@ class NA2DTests(unittest.TestCase):
         device="cuda",
         eps=1e-6,
         L_extra=9,
+        broadcast_extra_kv_batch=False,
     ):
         assert L_extra > 0
         kwargs = {"device": device, "dtype": dtype}
@@ -679,9 +680,20 @@ class NA2DTests(unittest.TestCase):
                 rpb = torch.randn(H, 2 * kernel_size - 1, 2 * kernel_size - 1, **kwargs)
                 rpb_ref = rpb.clone()
 
-            extra_k = torch.randn((B, H, L_extra, D), **kwargs)
-            extra_v = torch.randn((B, H, L_extra, D), **kwargs)
+            extra_k = torch.randn(
+                (1 if broadcast_extra_kv_batch else B, H, L_extra, D), **kwargs
+            )
+            extra_v = torch.randn(
+                (1 if broadcast_extra_kv_batch else B, H, L_extra, D), **kwargs
+            )
             extra_k_ref, extra_v_ref = extra_k.clone(), extra_v.clone()
+            if broadcast_extra_kv_batch:
+                extra_k, extra_v = extra_k.expand(B, H, L_extra, D), extra_v.expand(
+                    B, H, L_extra, D
+                )
+                extra_k_ref, extra_v_ref = extra_k_ref.repeat(
+                    B, 1, 1, 1
+                ), extra_v_ref.repeat(B, 1, 1, 1)
 
             # Reference implementation
             attn_extra_ref = (
@@ -760,6 +772,19 @@ class NA2DTests(unittest.TestCase):
             dtype=torch.float32,
             device="cpu",
         )
+        self._test_with_extra_tokens(
+            B=B,
+            H=H,
+            X=X,
+            Y=Y,
+            D=D,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            has_bias=has_bias,
+            dtype=torch.float32,
+            device="cpu",
+            broadcast_extra_kv_batch=True,
+        )
 
     def _test_cuda_with_extra_tokens(
         self, B, H, X, Y, D, kernel_size, dilation, has_bias=False
@@ -779,6 +804,19 @@ class NA2DTests(unittest.TestCase):
             has_bias=has_bias,
             dtype=torch.float32,
             device="cuda",
+        )
+        self._test_with_extra_tokens(
+            B=B,
+            H=H,
+            X=X,
+            Y=Y,
+            D=D,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            has_bias=has_bias,
+            dtype=torch.float32,
+            device="cuda",
+            broadcast_extra_kv_batch=True,
         )
         if HAS_HALF:
             self._test_with_extra_tokens(

--- a/tests/test_na3d.py
+++ b/tests/test_na3d.py
@@ -627,6 +627,7 @@ class NA3DTests(unittest.TestCase):
         device="cuda",
         eps=1e-6,
         L_extra=9,
+        broadcast_extra_kv_batch=False,
     ):
         assert L_extra > 0
         kwargs = {"device": device, "dtype": dtype}
@@ -649,9 +650,20 @@ class NA3DTests(unittest.TestCase):
                 )
                 rpb_ref = rpb.clone()
 
-            extra_k = torch.randn((B, H, L_extra, D), **kwargs)
-            extra_v = torch.randn((B, H, L_extra, D), **kwargs)
+            extra_k = torch.randn(
+                (1 if broadcast_extra_kv_batch else B, H, L_extra, D), **kwargs
+            )
+            extra_v = torch.randn(
+                (1 if broadcast_extra_kv_batch else B, H, L_extra, D), **kwargs
+            )
             extra_k_ref, extra_v_ref = extra_k.clone(), extra_v.clone()
+            if broadcast_extra_kv_batch:
+                extra_k, extra_v = extra_k.expand(B, H, L_extra, D), extra_v.expand(
+                    B, H, L_extra, D
+                )
+                extra_k_ref, extra_v_ref = extra_k_ref.repeat(
+                    B, 1, 1, 1
+                ), extra_v_ref.repeat(B, 1, 1, 1)
 
             # Reference implementation
             attn_extra_ref = (
@@ -746,6 +758,20 @@ class NA3DTests(unittest.TestCase):
             dtype=torch.float32,
             device="cpu",
         )
+        self._test_with_extra_tokens(
+            B=B,
+            H=H,
+            X=X,
+            Y=Y,
+            Z=Z,
+            D=D,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            has_bias=has_bias,
+            dtype=torch.float32,
+            device="cpu",
+            broadcast_extra_kv_batch=True,
+        )
 
     def _test_cuda_with_extra_tokens(
         self, B, H, X, Y, Z, D, kernel_size, dilation, has_bias=False
@@ -762,6 +788,20 @@ class NA3DTests(unittest.TestCase):
             has_bias=has_bias,
             dtype=torch.float32,
             device="cuda",
+        )
+        self._test_with_extra_tokens(
+            B=B,
+            H=H,
+            X=X,
+            Y=Y,
+            Z=Z,
+            D=D,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            has_bias=has_bias,
+            dtype=torch.float32,
+            device="cuda",
+            broadcast_extra_kv_batch=True,
         )
         if HAS_HALF:
             self._test_with_extra_tokens(

--- a/tools/profile_2d_with_extra_tokens.py
+++ b/tools/profile_2d_with_extra_tokens.py
@@ -45,6 +45,7 @@ from utils.profiler_2d import profile_na2d_extra_tokens
 @click.option("--disable-tf32", is_flag=True)
 @click.option("--warmup-steps", default=10)
 @click.option("--disable-fusion", is_flag=True)
+@click.option("--broadcast-batch", is_flag=True)
 def profile_2d(
     batch_size: int,
     heads: int,
@@ -61,6 +62,7 @@ def profile_2d(
     disable_tf32: bool,
     warmup_steps: int,
     disable_fusion: bool,
+    broadcast_batch: bool,
 ):
 
     dtype = torch.float32
@@ -87,6 +89,7 @@ def profile_2d(
         dtype=dtype,
         warmup_steps=warmup_steps,
         disable_concat_fusion=disable_fusion,
+        broadcast_batch=broadcast_batch,
     )
 
     title = "Profiler results"


### PR DESCRIPTION
Switching from torch.bmm to torch.matmul for cross attention ops. The former only accepts rank-3 tensors as inputs, but the latter allows variable rank inputs, and handles different cases with the necessary transformations. If we stick to torch.bmm, and the key-value pair is being broadcast along the batch dimension, we wouldn't be able to flatten the batch and head dimensions to get the rank-3 tensor, so we would be forcing users to explicitly repeat the tensor to create a batch dimension.

torch.matmul appears to require very minor transformations and still support working with views. In addition, those transformations will not occur if there is no batch broadcasting, so previous use cases will be unaffected.

Unit tests for broadcasted KV tokens have been added, and the profiling script for cross attention adds a new option, `--broadcast-batch`.

#82.