### PR TITLE
Build fixes and requirements.txt cleanup

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -14,9 +14,13 @@ endif()
 set(CXX_STD "17" CACHE STRING "C++ standard")
 
 
-# Find Python
-find_package(Python 3.7 COMPONENTS Interpreter Development REQUIRED)
-set(PYTHON_PATH "python" CACHE STRING "Python path")
+if(NOT DEFINED PYTHON_PATH)
+    # Find Python
+		message("Python path not specified; looking up local python.")
+    find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+    set(PYTHON_PATH "python" CACHE STRING "Python path")
+endif()
+message("Python: " ${PYTHON_PATH})
 
 ## Python includes 
 execute_process(COMMAND ${PYTHON_PATH} "-c" "from __future__ import print_function; from distutils import sysconfig; print(sysconfig.get_python_inc());"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+-f https://download.pytorch.org/whl/cu121
+torch==2.1.2
+cmake==3.20.3
+ufmt==2.3.0
+flake8==7.0.0
+mypy==1.8.0
+pytest==7.4.4
+click==8.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
--f https://download.pytorch.org/whl/cu121
-torch==2.1.2
+torch>=2.0.0
 cmake==3.20.3
-ufmt==2.3.0
-flake8==7.0.0
-mypy==1.8.0
-pytest==7.4.4
-click==8.1.7

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ class BuildExtension(build_ext):
             print(f"Current arch list: {cuda_arch_list} (max: {max_sm})")
 
         cmake_args = [
+            f"-DPYTHON_PATH={sys.executable}",
             f"-DOUTPUT_FILE_NAME={output_so_name}",
             f"-DNATTEN_CUDA_ARCH_LIST={cuda_arch_list_str}",
             f"-DNATTEN_IS_WINDOWS={int(IS_WINDOWS)}",


### PR DESCRIPTION
* Pass PYTHON_PATH to cmake. Having CMake decide which python environment / install to use is both counter-intuitive (given that python's setuptools is calling cmake to begin with), and can be a problem for users that can't use wheels. Setuptools should pass the python path to avoid this issue. If unspecified, cmake can figure out the python path (although in the ideal case it should be able to build without python, which can happen once we get rid of the torch dependency, but we can worry about that later.)

* requirements.txt should only include hard dependencies. Torch is a dependency, and cmake should be there in case there's no cmake at the OS level, or it's the wrong version.

  NOTE: cmake binaries installed through pypi on Intel macs tends to crash right from the get-go. This should be investigated.


Fixes #90.