### PR TITLE
Fix attention autocast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,3 @@ dmypy.json
 
 # Output files
 *.out
-
-# Don't commit manifest.in
-MANIFEST.in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,24 @@
 
 ## [0.15.1] - 2024-01-24
 * Attention tensors can now be views, which allows combining neighborhood and any other attention pattern (i.e. registers,
-  cross attention tokens, and the like) without extra copies. (#85 and #87).
-* Minor bug fixes (#86).
+  cross attention tokens, and the like) without extra copies. ([#85](https://github.com/SHI-Labs/NATTEN/pull/85) and [#87](https://github.com/SHI-Labs/NATTEN/pull/87)).
+* Minor bug fixes ([#86](https://github.com/SHI-Labs/NATTEN/pull/86) and [#94](https://github.com/SHI-Labs/NATTEN/pull/94)).
 
 ## [0.15.0] - 2024-01-09
 * Refactored kernels
   * The backend is messy, particularly the CUDA backend. A step in the right direction is at least factoring out duplicated.
   * Out of the 7 operations in NATTEN's backend, 6 have duplicates (really 3 underlying ops with different inputs.)
-  * See #26 for more details.
+  * See [#26](https://github.com/SHI-Labs/NATTEN/pull/26) for more details.
 * 3D Neighborhood Attention: naive CPU and CUDA kernels were added.
-* Major refactoring of the C++ API (#38, #47, #53, and #81)
-* GEMM kernels (#38 and #47)
-* New build system with cmake (#38, #53, #81)
-* Bfloat16 support (#38 and #81)
-* Kepler and Maxwell support (#81)
-* Forward mode automatic differentiation support (#74)
-* Experimental support for Nested Tensors (inference only) (#76)
-* Type checking, clang format, and other typesetting/formatting changes (#80)
-* Added profiling scripts (#81)
+* Major refactoring of the C++ API ([#38](https://github.com/SHI-Labs/NATTEN/pull/38), [#47](https://github.com/SHI-Labs/NATTEN/pull/47), [#53](https://github.com/SHI-Labs/NATTEN/pull/53), and [#81](https://github.com/SHI-Labs/NATTEN/pull/81))
+* GEMM kernels ([#38](https://github.com/SHI-Labs/NATTEN/pull/38) and [#47](https://github.com/SHI-Labs/NATTEN/pull/47))
+* New build system with cmake ([#38](https://github.com/SHI-Labs/NATTEN/pull/38), [#53](https://github.com/SHI-Labs/NATTEN/pull/53), [#81](https://github.com/SHI-Labs/NATTEN/pull/81))
+* Bfloat16 support ([#38](https://github.com/SHI-Labs/NATTEN/pull/38) and [#81](https://github.com/SHI-Labs/NATTEN/pull/81))
+* Kepler and Maxwell support ([#81](https://github.com/SHI-Labs/NATTEN/pull/81))
+* Forward mode automatic differentiation support ([#74](https://github.com/SHI-Labs/NATTEN/pull/74))
+* Experimental support for Nested Tensors (inference only) ([#76](https://github.com/SHI-Labs/NATTEN/pull/76))
+* Type checking, clang format, and other typesetting/formatting changes ([#80](https://github.com/SHI-Labs/NATTEN/pull/80))
+* Added profiling scripts ([#81](https://github.com/SHI-Labs/NATTEN/pull/81))
 
 ## [0.14.6] - 2023-03-21
 Just a really small update that syncs the changes to the private branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.1] - 2024-01-24
+* Attention tensors can now be views, which allows combining neighborhood and any other attention pattern (i.e. registers,
+  cross attention tokens, and the like) without extra copies. (#85 and #87).
+* Minor bug fixes (#86).
+
 ## [0.15.0] - 2024-01-09
 * Refactored kernels
   * The backend is messy, particularly the CUDA backend. A step in the right direction is at least factoring out duplicated.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+recursive-include csrc *.cpp *.cuh *.cu *.h *.txt *.hpp *.cc
+recursive-include third_party/cutlass/include *.cpp *.cuh *.cu *.h *.txt *.hpp *.cc
+prune webpage/
+prune tools/
+prune scripts/
+prune tests/
+graft assets/

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ release:
 
 clean: 
 	@echo "Cleaning up"
-	rm -rf build/ 
 	rm -rf dist/ 
 	rm -rf natten.egg-info/ 
 	rm -rf src/natten/_C.* 

--- a/src/natten/__init__.py
+++ b/src/natten/__init__.py
@@ -59,4 +59,4 @@ __all__ = [
     "has_fp64_gemm",
 ]
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -270,6 +270,7 @@ class NeighborhoodAttention1DAVAutogradFunction(Function):
         dilation: int,
     ):
         num_na_weights = kernel_size
+        attn = attn.to(value.dtype)
         value = value.contiguous()
         out = torch.empty_like(value)
         out_add = None
@@ -318,6 +319,7 @@ class NeighborhoodAttention1DAVAutogradFunction(Function):
                 "Expected either both additional_value_t and additional_value_p, or neither."
             )
 
+        attn_t = attn_t.to(value_t.dtype)
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
         out_0 = torch.empty_like(value_p)
@@ -544,6 +546,7 @@ class NeighborhoodAttention2DAVAutogradFunction(Function):
         dilation: int,
     ) -> Tensor:
         num_na_weights = kernel_size**2
+        attn = attn.to(value.dtype)
         value = value.contiguous()
         out = torch.empty_like(value)
         out_add = None
@@ -592,6 +595,7 @@ class NeighborhoodAttention2DAVAutogradFunction(Function):
                 "Expected either both additional_value_t and additional_value_p, or neither."
             )
 
+        attn_t = attn_t.to(value_t.dtype)
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
         out_0 = torch.empty_like(value_p)
@@ -849,6 +853,7 @@ class NeighborhoodAttention3DAVAutogradFunction(Function):
         dilation: int,
     ) -> Tensor:
         num_na_weights = kernel_size_d * kernel_size * kernel_size
+        attn = attn.to(value.dtype)
         value = value.contiguous()
         out = torch.empty_like(value)
         out_add = None
@@ -901,6 +906,7 @@ class NeighborhoodAttention3DAVAutogradFunction(Function):
                 "Expected either both additional_value_t and additional_value_p, or neither."
             )
 
+        attn_t = attn_t.to(value_t.dtype)
         attn_t = attn_t.contiguous()
         value_t = value_t.contiguous()
         out_0 = torch.empty_like(value_p)

--- a/src/natten/nested.py
+++ b/src/natten/nested.py
@@ -144,6 +144,7 @@ def na1d_av_nested(
             "nested."
         )
 
+    attn = attn.to(value.dtype)
     out = torch.empty_like(value)
     additional_values_list: List | Tensor = (
         [None for _ in range(attn.size(0))]
@@ -273,6 +274,7 @@ def na2d_av_nested(
             "nested."
         )
 
+    attn = attn.to(value.dtype)
     out = torch.empty_like(value)
     additional_values_list: List | Tensor = (
         [None for _ in range(attn.size(0))]
@@ -408,6 +410,7 @@ def na3d_av_nested(
             "nested."
         )
 
+    attn = attn.to(value.dtype)
     out = torch.empty_like(value)
     additional_values_list: List | Tensor = (
         [None for _ in range(attn.size(0))]

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -73,15 +73,15 @@
                   <div class="tab-content" id="v210-tabContent">
                     <div class="tab-pane fade show active" id="v210-121" role="tabpanel" aria-labelledby="v210-cu121-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cu121/torch2.1.0/index.html</pre>
+                      <pre>pip3 install natten==0.15.1+torch210cu121 -f https://shi-labs.com/natten/wheels/</pre>
                     </div>
                     <div class="tab-pane fade" id="v210-118" role="tabpanel" aria-labelledby="v210-cu118-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cu118/torch2.1.0/index.html </pre>
+                      <pre>pip3 install natten==0.15.1+torch210cu118 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v210-cpu" role="tabpanel" aria-labelledby="v210-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cpu/torch2.1.0/index.html </pre>
+                      <pre>pip3 install natten==0.15.1+torch210cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -96,15 +96,15 @@
                   <div class="tab-content" id="v200-tabContent">
                     <div class="tab-pane fade show active" id="v200-118" role="tabpanel" aria-labelledby="v200-cu118-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cu118/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.15.1+torch200cu118 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v200-117" role="tabpanel" aria-labelledby="v200-cu117-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cu117/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.15.1+torch200cu117 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v200-cpu" role="tabpanel" aria-labelledby="v200-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten -f https://shi-labs.com/natten/wheels/cpu/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.15.1+torch200cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -178,15 +178,15 @@
                   <div class="tab-content" id="v200-tabContent">
                     <div class="tab-pane fade show active" id="v200-118" role="tabpanel" aria-labelledby="v200-cu118-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu118/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch200cu118 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v200-117" role="tabpanel" aria-labelledby="v200-cu117-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu117/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch200cu117 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v200-cpu" role="tabpanel" aria-labelledby="v200-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch2.0.0/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch200cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -201,15 +201,15 @@
                   <div class="tab-content" id="v113-tabContent">
                     <div class="tab-pane fade show active" id="v113-117" role="tabpanel" aria-labelledby="v113-cu117-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu117/torch1.13/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1130cu117 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v113-116" role="tabpanel" aria-labelledby="v113-cu116-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu116/torch1.13/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1130cu116 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v113-cpu" role="tabpanel" aria-labelledby="v113-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.13/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1130cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -225,19 +225,19 @@
                   <div class="tab-content" id="v1121-tabContent">
                     <div class="tab-pane fade show active" id="v1121-116" role="tabpanel" aria-labelledby="v1121-cu116-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu116/torch1.12.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1121cu116 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1121-113" role="tabpanel" aria-labelledby="v1121-cu113-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu113/torch1.12.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1121cu113 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1121-102" role="tabpanel" aria-labelledby="v1121-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.12.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1121cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1121-cpu" role="tabpanel" aria-labelledby="v1121-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.12.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1121cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -253,19 +253,19 @@
                   <div class="tab-content" id="v1120-tabContent">
                     <div class="tab-pane fade show active" id="v1120-116" role="tabpanel" aria-labelledby="v1120-cu116-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu116/torch1.12/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1120cu116 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1120-113" role="tabpanel" aria-labelledby="v1120-cu113-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu113/torch1.12/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1120cu113 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1120-102" role="tabpanel" aria-labelledby="v1120-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.12/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1120cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1120-cpu" role="tabpanel" aria-labelledby="v1120-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.12/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1120cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -281,19 +281,19 @@
                   <div class="tab-content" id="v1110-tabContent">
                     <div class="tab-pane fade show active" id="v1110-115" role="tabpanel" aria-labelledby="v1110-cu115-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu115/torch1.11/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch111cu115 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1110-113" role="tabpanel" aria-labelledby="v1110-cu113-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu113/torch1.11/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch111cu113 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1110-102" role="tabpanel" aria-labelledby="v1110-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.11/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch111cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1110-cpu" role="tabpanel" aria-labelledby="v1110-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.11/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch111cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -309,19 +309,19 @@
                   <div class="tab-content" id="v1101-tabContent">
                     <div class="tab-pane fade show active" id="v1101-113" role="tabpanel" aria-labelledby="v1101-cu113-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu113/torch1.10.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1101cu113 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1101-111" role="tabpanel" aria-labelledby="v1101-cu111-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu111/torch1.10.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1101cu111 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1101-102" role="tabpanel" aria-labelledby="v1101-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.10.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1101cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1101-cpu" role="tabpanel" aria-labelledby="v1101-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.10.1/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch1101cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -337,19 +337,19 @@
                   <div class="tab-content" id="v1100-tabContent">
                     <div class="tab-pane fade show active" id="v1100-113" role="tabpanel" aria-labelledby="v1100-cu113-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu113/torch1.10/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch110cu113 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1100-111" role="tabpanel" aria-labelledby="v1100-cu111-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu111/torch1.10/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch110cu111 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1100-102" role="tabpanel" aria-labelledby="v1100-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.10/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch110cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1100-cpu" role="tabpanel" aria-labelledby="v1100-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.10/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch110cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -364,15 +364,15 @@
                   <div class="tab-content" id="v1090-tabContent">
                     <div class="tab-pane fade show active" id="v1090-111" role="tabpanel" aria-labelledby="v1090-cu111-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu111/torch1.9/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch190cu111 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1090-102" role="tabpanel" aria-labelledby="v1090-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.9/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch190cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1090-cpu" role="tabpanel" aria-labelledby="v1090-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.9/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch190cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>
@@ -388,19 +388,19 @@
                   <div class="tab-content" id="v1080-tabContent">
                     <div class="tab-pane fade show active" id="v1080-111" role="tabpanel" aria-labelledby="v1080-cu111-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu111/torch1.8/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch180cu111 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1080-102" role="tabpanel" aria-labelledby="v1080-cu102-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu102/torch1.8/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch180cu102 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1080-101" role="tabpanel" aria-labelledby="v1080-cu101-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cu101/torch1.8/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch180cu101 -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                     <div class="tab-pane fade" id="v1080-cpu" role="tabpanel" aria-labelledby="v1080-cpu-tab">
                       <p>Run this command:</p>
-                      <pre>pip3 install natten==0.14.6 -f https://shi-labs.com/natten/wheels/cpu/torch1.8/index.html </pre>
+                      <pre>pip3 install natten==0.14.6+torch180cpu -f https://shi-labs.com/natten/wheels</pre>
                     </div>
                   </div>
                 </div>

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -44,7 +44,7 @@
     <div class="title row">
         <div class="col-lg-12">
             <p class="h2">Install with pip</p>
-            <p>Latest release: <code>0.15.0</code></p>
+            <p>Latest release: <code>0.15.1</code></p>
         </div>
     </div>
     <div class="row">
@@ -110,7 +110,7 @@
                 </div>
               </div>
           </div>
-          <p>Your build isn't listed? Mac user? Just do: <pre class="tight">pip install natten==0.15.0</pre></p>
+          <p>Your build isn't listed? Mac user? Just do: <pre class="tight">pip install natten==0.15.1</pre></p>
           <p>Careful though, without precompiled wheels installing might take a while.</p>
           <p>You're also required to have CUDA &gt; 11.0, cmake &gt; 3.20 and PyTorch &gt; 2.0 installed before attempting to install/build NATTEN.</p>
           <p></p>


### PR DESCRIPTION
Torch autocasts attention weights into FP32 because of softmax, but doesn't autocast back into the user-specified data type.

Up until recently, we explicitly passed the autocast dtype in all autograd function wrappers (reference:
    https://github.com/SHI-Labs/NATTEN/blob/3b54c76185904f3cb59a49fff7bc044e4513d106/src/natten/functional.py#L149),
but this is wrong, because the user might be doing BF16.

According to the latest torch documentation, this has not been changed since the first NATTEN release.

Because it's error prone, this commit explicitly calls cast on all attention tensors to match the dtype of value. If it's already matching,
          torch will ignore it, and it shouldn't really get in the way
          of AMP mechanics.

Reference: #93