### PR TITLE
Support for docker buildkit builds without gpu present

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ if HAS_CUDA:
 
     assert CUDA_VERSION >= [11, 0], "NATTEN only supports CUDA 11.0 and above."
 
+DEFAULT_CUDA_ARCH_LIST = os.environ.get("DEFAULT_CUDA_ARCH_LIST", "")
 cuda_arch = os.environ.get("NATTEN_CUDA_ARCH", DEFAULT_CUDA_ARCH_LIST)
 # In case the env variable is set, but to an empty string
 if cuda_arch == "":
@@ -78,7 +79,7 @@ if cuda_arch == "":
 
 n_workers = os.environ.get("NATTEN_N_WORKERS", DEFAULT_N_WORKERS)
 # In case the env variable is set, but to an empty string
-if n_workers == "":
+if n_workers == "":DEFAULT_CUDA_ARCH_LIST
     n_workers = DEFAULT_N_WORKERS
 
 if HAS_CUDA:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ HAS_CUDA = (
 )
 NATTEN_IS_BUILDING_DIST = bool(os.getenv("NATTEN_IS_BUILDING_DIST", 0))
 DEFAULT_N_WORKERS = max(1, (multiprocessing.cpu_count() // 4))
-DEFAULT_CUDA_ARCH_LIST = os.getenv("TORCH_CUDA_ARCH_LIST", "")
+cuda_arch = os.getenv("NATTEN_CUDA_ARCH", "")
 if HAS_CUDA:
     if not DEFAULT_CUDA_ARCH_LIST:
         cuda_device = torch.cuda.get_device_properties(torch.cuda.current_device())

--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,10 @@ NATTEN_IS_BUILDING_DIST = bool(os.getenv("NATTEN_IS_BUILDING_DIST", 0))
 DEFAULT_N_WORKERS = max(1, (multiprocessing.cpu_count() // 4))
 cuda_arch = os.getenv("NATTEN_CUDA_ARCH", "")
 if HAS_CUDA:
-    if not DEFAULT_CUDA_ARCH_LIST:
+    if not cuda_arch:
         cuda_device = torch.cuda.get_device_properties(torch.cuda.current_device())
         sm = cuda_device.major + cuda_device.minor * 0.1
-        DEFAULT_CUDA_ARCH_LIST = f"{sm}"
+        cuda_arch = f"{sm}"
 
     # TODO: raise an error or at least a warning when torch cuda doesn't match
     # system.

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ if HAS_CUDA:
 
     assert CUDA_VERSION >= [11, 0], "NATTEN only supports CUDA 11.0 and above."
 
-DEFAULT_CUDA_ARCH_LIST = os.environ.get("DEFAULT_CUDA_ARCH_LIST", "")
-cuda_arch = os.environ.get("NATTEN_CUDA_ARCH", DEFAULT_CUDA_ARCH_LIST)
 # In case the env variable is set, but to an empty string
 if cuda_arch == "":
     cuda_arch = DEFAULT_CUDA_ARCH_LIST

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,12 @@ HAS_CUDA = (
 )
 NATTEN_IS_BUILDING_DIST = bool(os.getenv("NATTEN_IS_BUILDING_DIST", 0))
 DEFAULT_N_WORKERS = max(1, (multiprocessing.cpu_count() // 4))
-DEFAULT_CUDA_ARCH_LIST = ""
+DEFAULT_CUDA_ARCH_LIST = os.getenv("TORCH_CUDA_ARCH_LIST", "")
 if HAS_CUDA:
-    cuda_device = torch.cuda.get_device_properties(torch.cuda.current_device())
-    sm = cuda_device.major + cuda_device.minor * 0.1
-    DEFAULT_CUDA_ARCH_LIST = f"{sm}"
+    if not DEFAULT_CUDA_ARCH_LIST:
+        cuda_device = torch.cuda.get_device_properties(torch.cuda.current_device())
+        sm = cuda_device.major + cuda_device.minor * 0.1
+        DEFAULT_CUDA_ARCH_LIST = f"{sm}"
 
     # TODO: raise an error or at least a warning when torch cuda doesn't match
     # system.

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if cuda_arch == "":
 
 n_workers = os.environ.get("NATTEN_N_WORKERS", DEFAULT_N_WORKERS)
 # In case the env variable is set, but to an empty string
-if n_workers == "":DEFAULT_CUDA_ARCH_LIST
+if n_workers == "":
     n_workers = DEFAULT_N_WORKERS
 
 if HAS_CUDA:

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,6 @@ if HAS_CUDA:
 
     assert CUDA_VERSION >= [11, 0], "NATTEN only supports CUDA 11.0 and above."
 
-# In case the env variable is set, but to an empty string
-if cuda_arch == "":
-    cuda_arch = DEFAULT_CUDA_ARCH_LIST
 
 n_workers = os.environ.get("NATTEN_N_WORKERS", DEFAULT_N_WORKERS)
 # In case the env variable is set, but to an empty string


### PR DESCRIPTION
This allows NATTEN to be build without a GPU present by setting the TORCH_CUDA_ARCH_LIST env var.