### PR TITLE
Fix NGC builds

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -81,11 +81,11 @@ endif()
 
 set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++17")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall -ldl")
+set(CMAKE_CUDA_FLAGS "-Xcompiler -Wall -ldl")
 
 set(CMAKE_C_FLAGS_DEBUG    "${CMAKE_C_FLAGS_DEBUG}    -Wall -O0")
 set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG}  -Wall -O0")
-set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -O0 -G -Xcompiler -Wall")
+set(CMAKE_CUDA_FLAGS_DEBUG "-O0 -G -Xcompiler -Wall")
 
 set(CMAKE_CXX_STANDARD "${CXX_STD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -103,7 +103,13 @@ if(${NATTEN_WITH_CUDA})
 	message("NVCC executable: " ${CUDA_NVCC_EXECUTABLE})
 endif()
 
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+if(${IS_LIBTORCH_BUILT_WITH_CXX11_ABI})
+	message("Building with -D_GLIBCXX_USE_CXX11_ABI=1")
+  add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
+else()
+	message("Building with -D_GLIBCXX_USE_CXX11_ABI=0")
+  add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+endif()
 
 if(${NATTEN_WITH_CUDA})
 	# CUDA flags

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ from torch.utils.cpp_extension import CUDA_HOME, LIB_EXT
 IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform.startswith("darwin")
 IS_LINUX = sys.platform.startswith("linux")
+IS_LIBTORCH_BUILT_WITH_CXX11_ABI = torch._C._GLIBCXX_USE_CXX11_ABI
 
 this_directory = Path(__file__).parent
 try:
@@ -168,6 +169,7 @@ class BuildExtension(build_ext):
             f"-DNATTEN_CUDA_ARCH_LIST={cuda_arch_list_str}",
             f"-DNATTEN_IS_WINDOWS={int(IS_WINDOWS)}",
             f"-DNATTEN_IS_MAC={int(IS_MACOS)}",
+            f"-DIS_LIBTORCH_BUILT_WITH_CXX11_ABI={int(IS_LIBTORCH_BUILT_WITH_CXX11_ABI)}",
         ]
 
         if AVX_INT:


### PR DESCRIPTION
There were two mistakes in the cmakelists file;

1. The default CUDA_FLAGS value should be ignored, because we carefully selected our own, and the PyTorch cmake may or may not override it. In the case of #108, it was adding PTX for multiple previously unreferenced architectures (probably because of the torch environment variable being set in NGC images.)

2. Disabling the C++11 ABI flag should be conditioned on how libtorch was built.

Addresses #108.

CC: @KhrulkovV @dfyz