### PR TITLE
dRPB half fixes, enable FP16 for SM50, and more

### DIFF
--- a/csrc/autogen/src/cuda/naive/source_0.cu
+++ b/csrc/autogen/src/cuda/naive/source_0.cu
@@ -121,7 +121,7 @@ void na1d_pn_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = PointwiseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -152,7 +152,7 @@ void na1d_pn_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = PointwiseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -447,7 +447,7 @@ void na2d_pn_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -480,7 +480,7 @@ void na2d_pn_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -513,7 +513,7 @@ void na2d_pn_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -546,7 +546,7 @@ void na2d_pn_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1145,7 +1145,7 @@ void na3d_pn_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1180,7 +1180,7 @@ void na3d_pn_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1215,7 +1215,7 @@ void na3d_pn_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1250,7 +1250,7 @@ void na3d_pn_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1285,7 +1285,7 @@ void na3d_pn_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1320,7 +1320,7 @@ void na3d_pn_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1355,7 +1355,7 @@ void na3d_pn_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1390,7 +1390,7 @@ void na3d_pn_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1747,7 +1747,7 @@ void na1d_pn_bias_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = PointwiseNeighborhood1DWithBias<Arguments>;
   Kernel kernel;
@@ -1861,7 +1861,7 @@ void na2d_pn_bias_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = PointwiseNeighborhood2DWithBias<Arguments>;
   Kernel kernel;
@@ -1983,7 +1983,7 @@ void na3d_pn_bias_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = PointwiseNeighborhood3DWithBias<Arguments>;
   Kernel kernel;
@@ -2136,7 +2136,7 @@ void na1d_nn_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = NeighborhoodNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -2166,7 +2166,7 @@ void na1d_nn_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = NeighborhoodNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -2450,7 +2450,7 @@ void na2d_nn_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2482,7 +2482,7 @@ void na2d_nn_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2514,7 +2514,7 @@ void na2d_nn_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2546,7 +2546,7 @@ void na2d_nn_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;

--- a/csrc/autogen/src/cuda/naive/source_1.cu
+++ b/csrc/autogen/src/cuda/naive/source_1.cu
@@ -345,7 +345,7 @@ void na3d_nn_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -379,7 +379,7 @@ void na3d_nn_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -413,7 +413,7 @@ void na3d_nn_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -447,7 +447,7 @@ void na3d_nn_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -481,7 +481,7 @@ void na3d_nn_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -515,7 +515,7 @@ void na3d_nn_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -549,7 +549,7 @@ void na3d_nn_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -583,7 +583,7 @@ void na3d_nn_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -973,7 +973,7 @@ void na1d_in_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = InverseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -1003,7 +1003,7 @@ void na1d_in_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = InverseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -1287,7 +1287,7 @@ void na2d_in_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1319,7 +1319,7 @@ void na2d_in_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1351,7 +1351,7 @@ void na2d_in_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1383,7 +1383,7 @@ void na2d_in_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1961,7 +1961,7 @@ void na3d_in_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1995,7 +1995,7 @@ void na3d_in_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2029,7 +2029,7 @@ void na3d_in_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2063,7 +2063,7 @@ void na3d_in_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2097,7 +2097,7 @@ void na3d_in_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2131,7 +2131,7 @@ void na3d_in_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2165,7 +2165,7 @@ void na3d_in_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2199,7 +2199,7 @@ void na3d_in_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2542,7 +2542,7 @@ void na1d_rpbgrad_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = RelPosBiasGradient1D<Arguments>;
   Kernel kernel;
@@ -2648,7 +2648,7 @@ void na2d_rpbgrad_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = RelPosBiasGradient2D<Arguments>;
   Kernel kernel;
@@ -2762,7 +2762,7 @@ void na3d_rpbgrad_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 60) {
+if(cc >= 50) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = RelPosBiasGradient3D<Arguments>;
   Kernel kernel;

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_1d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_1d.cuh
@@ -31,12 +31,6 @@
 #include <natten/natten.h>
 #include <natten/cuda/naive/natten_commons.cuh>
 
-// TODO: We're still using ATen's atomic add!
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <torch/extension.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
-
 namespace natten {
 namespace cuda {
 namespace naive {
@@ -123,8 +117,7 @@ struct RelPosBiasGradient1DFull : RelPosBiasGradient1DBase<scalar_t, acc_t> {
         attnOffset += p.attn_stride_0;
       }
       int64_t index = h * p.bias_stride_0 + (pi + ki);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };
@@ -159,8 +152,7 @@ struct RelPosBiasGradient1DHalf : RelPosBiasGradient1DBase<scalar_t, acc_t> {
         attnOffset += p.attn_stride_0;
       }
       int64_t index = h * p.bias_stride_0 + (pi + ki);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_2d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_2d.cuh
@@ -31,12 +31,6 @@
 #include <natten/natten.h>
 #include <natten/cuda/naive/natten_commons.cuh>
 
-// TODO: We're still using ATen's atomic add!
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <torch/extension.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
-
 namespace natten {
 namespace cuda {
 namespace naive {
@@ -145,8 +139,7 @@ struct RelPosBiasGradient2DFull : RelPosBiasGradient2DBase<scalar_t, acc_t> {
       }
       int64_t index =
           h * p.bias_stride_0 + (pi + ki) * p.bias_stride_1 + (pj + kj);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };
@@ -193,8 +186,7 @@ struct RelPosBiasGradient2DHalf : RelPosBiasGradient2DBase<scalar_t, acc_t> {
       }
       int64_t index =
           h * p.bias_stride_0 + (pi + ki) * p.bias_stride_1 + (pj + kj);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_3d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_3d.cuh
@@ -31,12 +31,6 @@
 #include <natten/natten.h>
 #include <natten/cuda/naive/natten_commons.cuh>
 
-// TODO: We're still using ATen's atomic add!
-#include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
-#include <torch/extension.h>
-#include <ATen/native/cuda/KernelUtils.cuh>
-
 namespace natten {
 namespace cuda {
 namespace naive {
@@ -169,8 +163,7 @@ struct RelPosBiasGradient3DFull : RelPosBiasGradient3DBase<scalar_t, acc_t> {
       }
       int64_t index = h * p.bias_stride_0 + (pk + kk) * p.bias_stride_1 +
           (pi + ki) * p.bias_stride_2 + (pj + kj);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };
@@ -228,8 +221,7 @@ struct RelPosBiasGradient3DHalf : RelPosBiasGradient3DBase<scalar_t, acc_t> {
       }
       int64_t index = h * p.bias_stride_0 + (pk + kk) * p.bias_stride_1 +
           (pi + ki) * p.bias_stride_2 + (pj + kj);
-      at::native::fastAtomicAdd(
-          p.d_bias, index, p.problem_size, d_rpb_update, true);
+      atomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_11x11_13x13.cuh
+++ b/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_11x11_13x13.cuh
@@ -31,15 +31,13 @@
 */
 
 #pragma once
-// TODO: remaining dependency to torch: getCurrentCUDAStream
-#include <torch/extension.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "natten/cuda/naive/natten_commons.cuh"
-#include "natten/cuda/naive/natten_tiled_macros.cuh"
-#include "natten/cuda/naive/tiled/base.cuh"
+#include <natten/cuda/naive/natten_commons.cuh>
+#include <natten/cuda/naive/natten_tiled_macros.cuh>
+#include <natten/cuda/naive/tiled/base.cuh>
 
 namespace natten {
 namespace cuda {

--- a/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_3x3.cuh
+++ b/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_3x3.cuh
@@ -31,15 +31,13 @@
 */
 
 #pragma once
-// TODO: remaining dependency to torch: getCurrentCUDAStream
-#include <torch/extension.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "natten/cuda/naive/natten_commons.cuh"
-#include "natten/cuda/naive/natten_tiled_macros.cuh"
-#include "natten/cuda/naive/tiled/base.cuh"
+#include <natten/cuda/naive/natten_commons.cuh>
+#include <natten/cuda/naive/natten_tiled_macros.cuh>
+#include <natten/cuda/naive/tiled/base.cuh>
 
 namespace natten {
 namespace cuda {

--- a/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_5x5.cuh
+++ b/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_5x5.cuh
@@ -31,15 +31,13 @@
 */
 
 #pragma once
-// TODO: remaining dependency to torch: getCurrentCUDAStream
-#include <torch/extension.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "natten/cuda/naive/natten_commons.cuh"
-#include "natten/cuda/naive/natten_tiled_macros.cuh"
-#include "natten/cuda/naive/tiled/base.cuh"
+#include <natten/cuda/naive/natten_commons.cuh>
+#include <natten/cuda/naive/natten_tiled_macros.cuh>
+#include <natten/cuda/naive/tiled/base.cuh>
 
 namespace natten {
 namespace cuda {

--- a/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_7x7_9x9.cuh
+++ b/csrc/include/natten/cuda/naive/tiled/pointwise_neighborhood_2d_tiled_7x7_9x9.cuh
@@ -31,15 +31,13 @@
 */
 
 #pragma once
-// TODO: remaining dependency to torch: getCurrentCUDAStream
-#include <torch/extension.h>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#include "natten/cuda/naive/natten_commons.cuh"
-#include "natten/cuda/naive/natten_tiled_macros.cuh"
-#include "natten/cuda/naive/tiled/base.cuh"
+#include <natten/cuda/naive/natten_commons.cuh>
+#include <natten/cuda/naive/natten_tiled_macros.cuh>
+#include <natten/cuda/naive/tiled/base.cuh>
 
 namespace natten {
 namespace cuda {

--- a/csrc/include/natten/pytorch/cuda/helpers.cuh
+++ b/csrc/include/natten/pytorch/cuda/helpers.cuh
@@ -35,7 +35,7 @@
       fn_name<natten::float32>(cc, max_smem, stream, __VA_ARGS__);           \
     } else if (c10_dtype == torch::kDouble) {                                \
       fn_name<natten::float64>(cc, max_smem, stream, __VA_ARGS__);           \
-    } else if (c10_dtype == torch::kFloat16 && cc >= 60) {                   \
+    } else if (c10_dtype == torch::kFloat16 && cc >= 50) {                   \
       fn_name<natten::float16>(cc, max_smem, stream, __VA_ARGS__);           \
     } else if (c10_dtype == torch::kBFloat16 && cc >= 80) {                  \
       fn_name<natten::bfloat16>(cc, max_smem, stream, __VA_ARGS__);          \

--- a/csrc/src/pytorch/cuda/na1d.cu
+++ b/csrc/src/pytorch/cuda/na1d.cu
@@ -122,6 +122,22 @@ void na1d_qk_backward(
     const std::tuple<int32_t>& kernel_size,
     const std::tuple<int32_t>& dilation,
     const std::tuple<bool>& is_causal) {
+  // dRPB is always computed in FP32; there is no FP16/BF16 kernel for it.
+  auto should_cast_bias = false;
+  void* d_bias_ptr = nullptr;
+  at::optional<at::Tensor> d_bias_fp32;
+  if (d_bias.has_value()) {
+    auto d_bias_tensor = d_bias.value();
+    if (d_bias_tensor.scalar_type() == torch::kFloat16 ||
+        d_bias_tensor.scalar_type() == torch::kBFloat16) {
+      should_cast_bias = true;
+      d_bias_fp32 = at::zeros(
+          d_bias_tensor.sizes(), d_bias_tensor.options().dtype(torch::kFloat));
+      d_bias_ptr = static_cast<void*>(d_bias_fp32.value().data_ptr());
+    } else {
+      d_bias_ptr = static_cast<void*>(d_bias_tensor.data_ptr());
+    }
+  }
   DISPATCH_DTYPE(
       d_attn.device().index(),
       at::cuda::getCurrentCUDAStream(query.device().index()),
@@ -132,8 +148,7 @@ void na1d_qk_backward(
       static_cast<void*>(d_attn.data_ptr()),
       static_cast<void*>(d_query.data_ptr()),
       static_cast<void*>(d_key.data_ptr()),
-      d_bias.has_value() ? static_cast<void*>(d_bias.value().data_ptr())
-                         : nullptr,
+      d_bias_ptr,
       batch_size,
       heads,
       length,
@@ -144,6 +159,15 @@ void na1d_qk_backward(
       kernel_size,
       dilation,
       is_causal);
+  if (should_cast_bias) {
+    NATTEN_CHECK(
+        d_bias.has_value() && d_bias_fp32.has_value(),
+        "Something went wrong when casting biases. Please open an issue.");
+    auto d_bias_tensor = d_bias.value();
+    auto d_bias_fp32_tensor = d_bias_fp32.value();
+    auto d_bias_half = d_bias_fp32_tensor.toType(d_bias_tensor.scalar_type());
+    d_bias_tensor.copy_(d_bias_half);
+  }
 }
 
 void na1d_av_forward(

--- a/csrc/src/pytorch/cuda/na3d.cu
+++ b/csrc/src/pytorch/cuda/na3d.cu
@@ -134,6 +134,22 @@ void na3d_qk_backward(
     const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
     const std::tuple<int32_t, int32_t, int32_t>& dilation,
     const std::tuple<bool, bool, bool>& is_causal) {
+  // dRPB is always computed in FP32; there is no FP16/BF16 kernel for it.
+  auto should_cast_bias = false;
+  void* d_bias_ptr = nullptr;
+  at::optional<at::Tensor> d_bias_fp32;
+  if (d_bias.has_value()) {
+    auto d_bias_tensor = d_bias.value();
+    if (d_bias_tensor.scalar_type() == torch::kFloat16 ||
+        d_bias_tensor.scalar_type() == torch::kBFloat16) {
+      should_cast_bias = true;
+      d_bias_fp32 = at::zeros(
+          d_bias_tensor.sizes(), d_bias_tensor.options().dtype(torch::kFloat));
+      d_bias_ptr = static_cast<void*>(d_bias_fp32.value().data_ptr());
+    } else {
+      d_bias_ptr = static_cast<void*>(d_bias_tensor.data_ptr());
+    }
+  }
   DISPATCH_DTYPE(
       d_attn.device().index(),
       at::cuda::getCurrentCUDAStream(query.device().index()),
@@ -144,8 +160,7 @@ void na3d_qk_backward(
       static_cast<void*>(d_attn.data_ptr()),
       static_cast<void*>(d_query.data_ptr()),
       static_cast<void*>(d_key.data_ptr()),
-      d_bias.has_value() ? static_cast<void*>(d_bias.value().data_ptr())
-                         : nullptr,
+      d_bias_ptr,
       batch_size,
       heads,
       depth,
@@ -160,6 +175,15 @@ void na3d_qk_backward(
       kernel_size,
       dilation,
       is_causal);
+  if (should_cast_bias) {
+    NATTEN_CHECK(
+        d_bias.has_value() && d_bias_fp32.has_value(),
+        "Something went wrong when casting biases. Please open an issue.");
+    auto d_bias_tensor = d_bias.value();
+    auto d_bias_fp32_tensor = d_bias_fp32.value();
+    auto d_bias_half = d_bias_fp32_tensor.toType(d_bias_tensor.scalar_type());
+    d_bias_tensor.copy_(d_bias_half);
+  }
 }
 
 void na3d_av_forward(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
--f https://download.pytorch.org/whl/cu121
-torch==2.1.2
+torch>=2.0.0
 cmake==3.20.3
 ufmt==2.3.0
 flake8==7.0.0

--- a/scripts/autogen_cuda_naive.py
+++ b/scripts/autogen_cuda_naive.py
@@ -375,7 +375,7 @@ class NaiveNAKernel:
         source_str += self.method_decl()
         source_str += " {\n"
         if self.dtype.name == "half":
-            source_str += "\nif(cc >= 60) {\n"
+            source_str += "\nif(cc >= 50) {\n"
         elif self.dtype.name == "bfloat16":
             source_str += "\nif(cc >= 80) {\n"
         source_str += self.method_def()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ if HAS_CUDA:
 
     # TODO: raise an error or at least a warning when torch cuda doesn't match
     # system.
+    assert torch.version.cuda is not None
     TORCH_CUDA_VERSION = [x for x in torch.version.cuda.split(".")[:2]]
     CUDA_TAG = "".join([x for x in TORCH_CUDA_VERSION])
     CUDA_VERSION = [int(x) for x in TORCH_CUDA_VERSION]

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -82,7 +82,7 @@ def has_cuda() -> bool:
 
 
 def has_half(device_index: Optional[_device_t] = None) -> bool:
-    return has_cuda() and get_device_cc(device_index) >= 60
+    return has_cuda() and get_device_cc(device_index) >= 50
 
 
 def has_bfloat(device_index: Optional[_device_t] = None) -> bool:

--- a/tools/utils/na_profiler.py
+++ b/tools/utils/na_profiler.py
@@ -266,7 +266,7 @@ def profile_na_with_torch(
 
     captured_num_ops = len(out)
     i = 0
-    while captured_num_ops != exp_num_ops and i < 50:
+    while captured_num_ops < exp_num_ops and i < 50:
         _ll = [f"{x.op_str}: {x.time_str}" for x in out]
         print(
             f"Not captured; trying again... {i=} {captured_num_ops=}, {exp_num_ops=}, {_ll}"


### PR DESCRIPTION
This commit forces the d_attn reduction (rpb gradient) to accumulate and store in FP32. Libnatten front-end creates a new tensor using torch api in these cases and converts the tensor back to the original data type. The additional latency is minimal, especially when compared to how expensive CAS-based atomics can be.

We're also enabling FP16 for SM50 (no reason why it shouldn't work; pending testing)

Other minor changes:
* Stop explicitly specifying torch releases in both requirement files
* Lint-related assertion in setup.py

Addresses #97 .