### PR TITLE
Disable 64x128x128 GEMM config for SM86 and 89

### DIFF
--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -38,7 +38,7 @@ except ImportError:
         " correct torch build: shi-labs.com/natten ."
     )
 
-from .autotuner import autotune_fna, disable_autotuner, enable_autotuner
+from .autotuner import autotune_fna, disable_autotuner, enable_autotuner, get_device_cc
 from .fna import disable_fna, enable_fna, is_fna_enabled
 from .nested import (
     na1d_av_nested,
@@ -71,10 +71,7 @@ is_fna_enabled = is_fna_enabled
 disable_fused_na = disable_fna
 enable_fused_na = enable_fna
 
-
-def get_device_cc(device_index: Optional[_device_t] = None) -> int:
-    major, minor = torch.cuda.get_device_capability(device_index)
-    return major * 10 + minor
+get_device_cc = get_device_cc
 
 
 def has_cuda() -> bool:


### PR DESCRIPTION
Noticed that FNA unit tests fail on SM86 because it can't handle any configs with a 64x128x128 GEMM tile size. Obviously due to shared memory limits and how SM80 and 86 share all their kernels but there's a huge disparity between A100/H100 (SM80 and SM90) and the rest of the GPUs in their respective generations (SM86 and SM89).

While I can't test SM89, I'm disabling the overly-large GEMM config for both just to be safe until we can test SM89, but I'm relatively confident that SM89 won't be able to handle the same config.