### PR TITLE
Fix determinism in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install:
 	NATTEN_CUDA_ARCH="${CUDA_ARCH}" NATTEN_N_WORKERS="${WORKERS}" NATTEN_VERBOSE="${VERBOSE}" pip install -v -e . 2>&1 | tee install.out
 
 test:
-	PYTORCH_NO_CUDA_MEMORY_CACHING=1 pytest -v -x ./tests
+	pytest -v -x ./tests
 
 style:
 	ufmt format $(check_dirs)

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -33,7 +33,7 @@ na3d_with_bias = NeighborhoodAttention3D(
   kernel_size=(7, 9, 9),
   dilation=(1, 1, 1),
   is_causal=False,
-  bias=True,
+  rel_pos_bias=True,
   num_heads=4)
 ```
 

--- a/tests/test_fna1d.py
+++ b/tests/test_fna1d.py
@@ -21,6 +21,7 @@
 #
 #################################################################################################
 
+import os
 import unittest
 
 import torch
@@ -33,11 +34,15 @@ from natten.utils.testing import (
     skip_if_fna_is_not_supported,
 )
 
-# NOTE: It is important to disable CUDNN benchmarking and TF32
-# because some tests are written with the assumption of relatively
-# good determinism. This affects certain torch builds, in particular
-# those in NGC images (mostly just built from source with different flags
-# compared to PyPI.)
+# NOTE: It is important to ensure determinism in torch GEMMs since
+# we don't write our own. Therefore we have to force determinism in
+# CUBLAS, and turn off CUDNN benchmarking (in case that backend
+# is built).
+# PT's caching allocator should also be turned off in unit tests for
+# when we run memcheck.
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+torch.use_deterministic_algorithms(True)
 torch.backends.cudnn.benchmark = False
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False

--- a/tests/test_fna2d.py
+++ b/tests/test_fna2d.py
@@ -21,6 +21,7 @@
 #
 #################################################################################################
 
+import os
 import unittest
 from itertools import product
 
@@ -34,11 +35,15 @@ from natten.utils.testing import (
     skip_if_fna_is_not_supported,
 )
 
-# NOTE: It is important to disable CUDNN benchmarking and TF32
-# because some tests are written with the assumption of relatively
-# good determinism. This affects certain torch builds, in particular
-# those in NGC images (mostly just built from source with different flags
-# compared to PyPI.)
+# NOTE: It is important to ensure determinism in torch GEMMs since
+# we don't write our own. Therefore we have to force determinism in
+# CUBLAS, and turn off CUDNN benchmarking (in case that backend
+# is built).
+# PT's caching allocator should also be turned off in unit tests for
+# when we run memcheck.
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+torch.use_deterministic_algorithms(True)
 torch.backends.cudnn.benchmark = False
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False

--- a/tests/test_fna3d.py
+++ b/tests/test_fna3d.py
@@ -21,6 +21,7 @@
 #
 #################################################################################################
 
+import os
 import unittest
 from itertools import product
 
@@ -34,11 +35,15 @@ from natten.utils.testing import (
     skip_if_fna_is_not_supported,
 )
 
-# NOTE: It is important to disable CUDNN benchmarking and TF32
-# because some tests are written with the assumption of relatively
-# good determinism. This affects certain torch builds, in particular
-# those in NGC images (mostly just built from source with different flags
-# compared to PyPI.)
+# NOTE: It is important to ensure determinism in torch GEMMs since
+# we don't write our own. Therefore we have to force determinism in
+# CUBLAS, and turn off CUDNN benchmarking (in case that backend
+# is built).
+# PT's caching allocator should also be turned off in unit tests for
+# when we run memcheck.
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+torch.use_deterministic_algorithms(True)
 torch.backends.cudnn.benchmark = False
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False

--- a/tests/test_na1d.py
+++ b/tests/test_na1d.py
@@ -862,7 +862,7 @@ class NA1DTests(unittest.TestCase):
         has_bias,
         dtype,
         device="cuda",
-        eps=1e-6,
+        eps=1e-4,
         L_extra=9,
         broadcast_extra_kv_batch=False,
     ):

--- a/tests/test_na2d.py
+++ b/tests/test_na2d.py
@@ -1114,7 +1114,7 @@ class NA2DTests(unittest.TestCase):
         has_bias,
         dtype,
         device="cuda",
-        eps=1e-6,
+        eps=1e-4,
         L_extra=9,
         broadcast_extra_kv_batch=False,
     ):

--- a/tests/test_na2d.py
+++ b/tests/test_na2d.py
@@ -49,11 +49,15 @@ from natten.utils.testing import (
 )
 from torch.autograd import gradcheck
 
-# NOTE: It is important to disable CUDNN benchmarking and TF32
-# because some tests are written with the assumption of relatively
-# good determinism. This affects certain torch builds, in particular
-# those in NGC images (mostly just built from source with different flags
-# compared to PyPI.)
+# NOTE: It is important to ensure determinism in torch GEMMs since
+# we don't write our own. Therefore we have to force determinism in
+# CUBLAS, and turn off CUDNN benchmarking (in case that backend
+# is built).
+# PT's caching allocator should also be turned off in unit tests for
+# when we run memcheck.
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+torch.use_deterministic_algorithms(True)
 torch.backends.cudnn.benchmark = False
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
@@ -1110,7 +1114,7 @@ class NA2DTests(unittest.TestCase):
         has_bias,
         dtype,
         device="cuda",
-        eps=1e-4,
+        eps=1e-6,
         L_extra=9,
         broadcast_extra_kv_batch=False,
     ):

--- a/tests/test_na3d.py
+++ b/tests/test_na3d.py
@@ -37,11 +37,15 @@ from natten.utils.testing import (
 )
 from torch.autograd import gradcheck
 
-# NOTE: It is important to disable CUDNN benchmarking and TF32
-# because some tests are written with the assumption of relatively
-# good determinism. This affects certain torch builds, in particular
-# those in NGC images (mostly just built from source with different flags
-# compared to PyPI.)
+# NOTE: It is important to ensure determinism in torch GEMMs since
+# we don't write our own. Therefore we have to force determinism in
+# CUBLAS, and turn off CUDNN benchmarking (in case that backend
+# is built).
+# PT's caching allocator should also be turned off in unit tests for
+# when we run memcheck.
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+torch.use_deterministic_algorithms(True)
 torch.backends.cudnn.benchmark = False
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
@@ -919,7 +923,7 @@ class NA3DTests(unittest.TestCase):
         has_bias,
         dtype,
         device="cuda",
-        eps=1e-4,
+        eps=1e-6,
         L_extra=9,
         broadcast_extra_kv_batch=False,
     ):

--- a/tests/test_na3d.py
+++ b/tests/test_na3d.py
@@ -923,7 +923,7 @@ class NA3DTests(unittest.TestCase):
         has_bias,
         dtype,
         device="cuda",
-        eps=1e-6,
+        eps=1e-4,
         L_extra=9,
         broadcast_extra_kv_batch=False,
     ):


### PR DESCRIPTION
Unit tests that use torch GEMMs (mostly just extra token tests) have
been very finicky because of non-deterministic paths in cuBLAS/cuDNN,
which are enabled by default. Torch releases built with cuDNN usually
pick that backend, and have flags of their own for ensuring determinism,
which were added recently to fix tests that are run in NGC containers.
However, standard pypi torch releases still randomly fail the extra
token unit tests, because we weren't using torch's higher level
`use_deterministic_algorithms` flag. When using that, we also have to
set cuBLAS's `CUBLAS_WORKSPACE_CONFIG`.

We also previously added the environment variable that disables the
caching allocator in case we're running memcheck, but it was just lazily
added to the makefile.

This commit fixes all of those, and makes the error tolerance for extra
token tests stricter.