### PR TITLE
Ban naive fp16 for sm50 again

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ Notes:
 | 3D            | fna          | :white_check_mark: | :white_check_mark: | :white_check_mark:       | Coming soon              | SM50      |
 
 Notes: 
-* FP16 kernels are only available on SM50 and above, and BF16 requires SM80 and above.
+* FP16 kernels are only available on SM50 and above*, and BF16 requires SM80 and above.
+  * Naive FP16 kernels are only available on **SM60** and above.
+  * FNA FP16 kernels are only available on SM50 and above.
 * GEMM backend on SM70 and SM75 can only do FP16.
 * Tiled only implements 1/3 of the ops, is only implemented for 2D problems, and requires head dim = 32.
 * Forward mode autograd does not support relative positional biases and causal masking yet.
 * Relative positional biases are not yet supported when any axis has causal masking enabled.
-* Naive backend allows FP16 for SM50 and above only. FP32/FP64 are available for SM35 and above.
 
 ## License
 NATTEN is released under the [MIT License](LICENSE).

--- a/csrc/autogen/src/cuda/naive/source_0.cu
+++ b/csrc/autogen/src/cuda/naive/source_0.cu
@@ -121,7 +121,7 @@ void na1d_pn_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = PointwiseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -152,7 +152,7 @@ void na1d_pn_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = PointwiseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -447,7 +447,7 @@ void na2d_pn_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -480,7 +480,7 @@ void na2d_pn_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -513,7 +513,7 @@ void na2d_pn_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -546,7 +546,7 @@ void na2d_pn_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = PointwiseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1145,7 +1145,7 @@ void na3d_pn_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1180,7 +1180,7 @@ void na3d_pn_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1215,7 +1215,7 @@ void na3d_pn_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1250,7 +1250,7 @@ void na3d_pn_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1285,7 +1285,7 @@ void na3d_pn_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1320,7 +1320,7 @@ void na3d_pn_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1355,7 +1355,7 @@ void na3d_pn_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1390,7 +1390,7 @@ void na3d_pn_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = PointwiseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1747,7 +1747,7 @@ void na1d_pn_bias_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = PointwiseNeighborhood1DWithBias<Arguments>;
   Kernel kernel;
@@ -1861,7 +1861,7 @@ void na2d_pn_bias_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = PointwiseNeighborhood2DWithBias<Arguments>;
   Kernel kernel;
@@ -1983,7 +1983,7 @@ void na3d_pn_bias_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = PointwiseNeighborhood3DWithBias<Arguments>;
   Kernel kernel;
@@ -2136,7 +2136,7 @@ void na1d_nn_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = NeighborhoodNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -2166,7 +2166,7 @@ void na1d_nn_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = NeighborhoodNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -2450,7 +2450,7 @@ void na2d_nn_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2482,7 +2482,7 @@ void na2d_nn_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2514,7 +2514,7 @@ void na2d_nn_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -2546,7 +2546,7 @@ void na2d_nn_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = NeighborhoodNeighborhood2D<Arguments>;
   Kernel kernel;

--- a/csrc/autogen/src/cuda/naive/source_1.cu
+++ b/csrc/autogen/src/cuda/naive/source_1.cu
@@ -345,7 +345,7 @@ void na3d_nn_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -379,7 +379,7 @@ void na3d_nn_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -413,7 +413,7 @@ void na3d_nn_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -447,7 +447,7 @@ void na3d_nn_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -481,7 +481,7 @@ void na3d_nn_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -515,7 +515,7 @@ void na3d_nn_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -549,7 +549,7 @@ void na3d_nn_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -583,7 +583,7 @@ void na3d_nn_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = NeighborhoodNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -973,7 +973,7 @@ void na1d_in_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = InverseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -1003,7 +1003,7 @@ void na1d_in_cuda_naive_half_cm_1(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 1>;
   using Kernel = InverseNeighborhood1D<Arguments>;
   Kernel kernel;
@@ -1287,7 +1287,7 @@ void na2d_in_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1319,7 +1319,7 @@ void na2d_in_cuda_naive_half_cm_0_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 1>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1351,7 +1351,7 @@ void na2d_in_cuda_naive_half_cm_1_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 0>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1383,7 +1383,7 @@ void na2d_in_cuda_naive_half_cm_1_1(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 1, 1>;
   using Kernel = InverseNeighborhood2D<Arguments>;
   Kernel kernel;
@@ -1961,7 +1961,7 @@ void na3d_in_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -1995,7 +1995,7 @@ void na3d_in_cuda_naive_half_cm_0_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2029,7 +2029,7 @@ void na3d_in_cuda_naive_half_cm_0_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2063,7 +2063,7 @@ void na3d_in_cuda_naive_half_cm_0_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 1, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2097,7 +2097,7 @@ void na3d_in_cuda_naive_half_cm_1_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2131,7 +2131,7 @@ void na3d_in_cuda_naive_half_cm_1_0_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 0, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2165,7 +2165,7 @@ void na3d_in_cuda_naive_half_cm_1_1_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 0>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2199,7 +2199,7 @@ void na3d_in_cuda_naive_half_cm_1_1_1(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 1, 1, 1>;
   using Kernel = InverseNeighborhood3D<Arguments>;
   Kernel kernel;
@@ -2542,7 +2542,7 @@ void na1d_rpbgrad_cuda_naive_half_cm_0(
   const std::tuple<int32_t>& kernel_size,
   const std::tuple<int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack1D<natten::float16, 0>;
   using Kernel = RelPosBiasGradient1D<Arguments>;
   Kernel kernel;
@@ -2648,7 +2648,7 @@ void na2d_rpbgrad_cuda_naive_half_cm_0_0(
   const std::tuple<int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack2D<natten::float16, 0, 0>;
   using Kernel = RelPosBiasGradient2D<Arguments>;
   Kernel kernel;
@@ -2762,7 +2762,7 @@ void na3d_rpbgrad_cuda_naive_half_cm_0_0_0(
   const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
   const std::tuple<int32_t, int32_t, int32_t>& dilation) {
 
-if(cc >= 50) {
+if(cc >= 60) {
   using Arguments = natten::naive::ArgumentPack3D<natten::float16, 0, 0, 0>;
   using Kernel = RelPosBiasGradient3D<Arguments>;
   Kernel kernel;

--- a/csrc/include/natten/cuda/naive/natten_commons.cuh
+++ b/csrc/include/natten/cuda/naive/natten_commons.cuh
@@ -423,6 +423,38 @@ struct AttnMask<natten::bfloat16> {
 
 #endif
 
+//////////////////////////////////////////////////
+/// Atomics for older architectures
+//////////////////////////////////////////////////
+
+#if defined(__CUDA_ARCH__)
+
+static inline __device__ float floatOrDoubleAtomicAdd(float *address, float val) {
+  return atomicAdd(address, val);
+}
+
+static inline __device__ double floatOrDoubleAtomicAdd(double* address, double val) {
+#if (__CUDA_ARCH__ >= 600)
+  return atomicAdd(address, val);
+#else
+  // Taken from pytorch;
+  // ATen/cuda/Atomic.cuh
+  unsigned long long int* address_as_ull = (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull;
+  unsigned long long int assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed, __double_as_longlong(val + __longlong_as_double(assumed)));
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+#endif
+}
+
+#endif
+
 } // namespace naive
 } // namespace cuda
 } // namespace natten

--- a/csrc/include/natten/cuda/naive/natten_commons.cuh
+++ b/csrc/include/natten/cuda/naive/natten_commons.cuh
@@ -59,9 +59,10 @@ struct LaunchParams {
 template <typename KernelTemplate>
 __global__ void launch_cuda_kernel(typename KernelTemplate::Params params) {
 #if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDA_ARCH__ > 300)
-#if (__CUDA_ARCH__ < 500)
-  // Half kernels are not supported in CC < 50,
-  // Partial FP16 support was added in SM54.
+#if (__CUDA_ARCH__ < 600)
+  // Half kernels are not supported in CC < 60,
+  // Partial FP16 support was added in SM50, but ours need the half2 type
+  // and ops, which aren't defined for SM50.
   // Also disabling tiled kernels, because older
   // architectures might not have enough shared memory
   // and the tiled kernels heavily rely on the assumed
@@ -101,7 +102,7 @@ struct HalfArray;
 template <typename ElementScalar_, typename ElementVector_>
 struct HalfArrayBase;
 
-#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDA_ARCH__ >= 500)
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDA_ARCH__ >= 600)
 
 template <>
 struct HalfArrayBase<natten::float16, __half2> {
@@ -400,7 +401,7 @@ struct AttnMask<float> {
   }
 };
 
-#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDA_ARCH__ >= 500)
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDA_ARCH__ >= 600)
 template <>
 struct AttnMask<natten::float16> {
   static __device__ auto value(bool is_grad) {

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_1d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_1d.cuh
@@ -117,7 +117,7 @@ struct RelPosBiasGradient1DFull : RelPosBiasGradient1DBase<scalar_t, acc_t> {
         attnOffset += p.attn_stride_0;
       }
       int64_t index = h * p.bias_stride_0 + (pi + ki);
-      atomicAdd(p.d_bias + index, d_rpb_update);
+      floatOrDoubleAtomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_2d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_2d.cuh
@@ -139,7 +139,7 @@ struct RelPosBiasGradient2DFull : RelPosBiasGradient2DBase<scalar_t, acc_t> {
       }
       int64_t index =
           h * p.bias_stride_0 + (pi + ki) * p.bias_stride_1 + (pj + kj);
-      atomicAdd(p.d_bias + index, d_rpb_update);
+      floatOrDoubleAtomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/csrc/include/natten/cuda/naive/rel_pos_bias_3d.cuh
+++ b/csrc/include/natten/cuda/naive/rel_pos_bias_3d.cuh
@@ -163,7 +163,7 @@ struct RelPosBiasGradient3DFull : RelPosBiasGradient3DBase<scalar_t, acc_t> {
       }
       int64_t index = h * p.bias_stride_0 + (pk + kk) * p.bias_stride_1 +
           (pi + ki) * p.bias_stride_2 + (pj + kj);
-      atomicAdd(p.d_bias + index, d_rpb_update);
+      floatOrDoubleAtomicAdd(p.d_bias + index, d_rpb_update);
     }
   }
 };

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,12 +27,8 @@ This leaves Windows users with only one option: WSL.
 
 Since [switching to cmake](https://github.com/SHI-Labs/NATTEN/tree/3036259bdc5c30b7b49fe8ba17d60a0ab0d780dd) for building
 libnatten, we have not been able to support MSVC builds.
-We just don't have a Windows machine to try and figure out the issue, especially one with CUDA.
-
-The first successful Windows build was thanks to users that were willing to share their logs and try out
-our commits, until the build issues were resolved.
-However, we haven't had much luck since the switch, so if you're willing,
-please reach out to us or refer to the [open issue](https://github.com/SHI-Labs/NATTEN/issues/18).)
+While we welcome contributions, we are not going to be able to fix MSVC builds any time in the near future,
+so we recommend building and running NATTEN with either WSL or MinGW.
 
 ### Building from source
 In order to build from source, please make sure that you have your preferred PyTorch build installed,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8==7.0.0
 mypy==1.8.0
 pytest==7.4.4
 click==8.1.7
+rich

--- a/scripts/autogen_cuda_naive.py
+++ b/scripts/autogen_cuda_naive.py
@@ -375,7 +375,7 @@ class NaiveNAKernel:
         source_str += self.method_decl()
         source_str += " {\n"
         if self.dtype.name == "half":
-            source_str += "\nif(cc >= 50) {\n"
+            source_str += "\nif(cc >= 60) {\n"
         elif self.dtype.name == "bfloat16":
             source_str += "\nif(cc >= 80) {\n"
         source_str += self.method_def()


### PR DESCRIPTION
We banned it originally not because SM50 didn't support FP16 math, but rather because the half2 intrinsics were unavailable, and all naive half kernels are written under the assumption that they are available.
Banning again.