### PR TITLE
Allow building without cuda runtime present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: sdist clean uninstall install-deps install test style quality
 
+WITH_CUDA=
 CUDA_ARCH=
 WORKERS=
 VERBOSE=
@@ -53,7 +54,11 @@ uninstall:
 
 install: 
 	@echo "Installing NATTEN from source"
-	NATTEN_CUDA_ARCH="${CUDA_ARCH}" NATTEN_N_WORKERS="${WORKERS}" NATTEN_VERBOSE="${VERBOSE}" pip install -v -e . 2>&1 | tee install.out
+	NATTEN_CUDA_ARCH="${CUDA_ARCH}" \
+			 NATTEN_N_WORKERS="${WORKERS}" \
+			 NATTEN_WITH_CUDA="${WITH_CUDA}" \
+			 NATTEN_VERBOSE="${VERBOSE}" \
+			 pip install -v -e . 2>&1 | tee install.out
 
 test:
 	pytest -v -x ./tests

--- a/dev/docker/Dockerfile.CUDA
+++ b/dev/docker/Dockerfile.CUDA
@@ -1,0 +1,18 @@
+# Copyright (c) 2022-2024 Ali Hassani.
+# This dockerfile builds on top of the March 2024 NGC PyTorch
+# image, and builds NATTEN for SM60-SM90 with 16 workers.
+
+FROM nvcr.io/nvidia/pytorch:24.03-py3
+
+RUN mkdir /natten
+
+RUN cd /natten && \
+      git clone https://github.com/SHI-Labs/NATTEN
+
+# NOTE: set WITH_CUDA=1 to prevent
+# setuptools from looking for the cuda runtime.
+RUN cd /natten/NATTEN && \
+      make \
+      WITH_CUDA=1 \
+      CUDA_ARCH="6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0" \
+      WORKERS=16

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,16 @@ More information on the issue: [pytorch/pytorch#116926](https://github.com/pytor
 NATTEN supports PyTorch builds that are built from source, an example of which is the builds that ship with
 NVIDIA's [NGC container images](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch).
 
-However, note that our PyPI wheels are only compatible with PyPI releases of PyTorch, which means you will have to build NATTEN
+If you're building NATTEN within a `Dockerfile`, be sure to specify the `CUDA_ARCH` and
+`WITH_CUDA` flags to make:
+
+```dockerfile
+RUN make \
+  WITH_CUDA=1 \
+  CUDA_ARCH="8.0;8.6"
+```
+
+Note that our PyPI wheels are only compatible with PyPI releases of PyTorch, which means you will have to build NATTEN
 from source if you built PyTorch from source (assuming you're on linux.)
 
 ### FAQ

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,6 +139,8 @@ RUN make \
   CUDA_ARCH="8.0;8.6"
 ```
 
+For a minimal example you can refer to [dev/docker](../dev/docker).
+
 Note that our PyPI wheels are only compatible with PyPI releases of PyTorch, which means you will have to build NATTEN
 from source if you built PyTorch from source (assuming you're on linux.)
 


### PR DESCRIPTION
NATTEN should allow users to specify an archtag and force building without cuda runtime present.
Use cases include, but are not limited to, building NATTEN as a container image.

Fixes #108.