### PR TITLE
Fixed some image links in the docs

### DIFF
--- a/docs/methodology/bmm.md
+++ b/docs/methodology/bmm.md
@@ -2,7 +2,7 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/batched_gemm_na_dark.png">
-  <img alt="Simplified visualization of GEMM-based neighborhood attention." src="../asserts/batched_gemm_na_light.png" />
+  <img alt="Simplified visualization of GEMM-based neighborhood attention." src="../assets/batched_gemm_na_light.png" />
 </picture>
 
 

--- a/docs/methodology/fused.md
+++ b/docs/methodology/fused.md
@@ -2,7 +2,7 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/fna_dark.png">
-  <img alt="Simplified visualization of fused neighborhood attention." src="../asserts/fna_light.png" />
+  <img alt="Simplified visualization of fused neighborhood attention." src="../assets/fna_light.png" />
 </picture>
 
 


### PR DESCRIPTION
There was a typo in the methodology asset links - "asserts" vs "assets". 