### PR TITLE
Update functional.py

### DIFF
--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -20,12 +20,15 @@
 # SOFTWARE.
 #
 #################################################################################################
+import functools
 from typing import Any, Optional, Tuple
 
 import torch
 from torch import Tensor
 from torch.autograd import Function
-from torch.cuda.amp import custom_bwd, custom_fwd
+from torch.amp import custom_bwd, custom_fwd                                              
+custom_fwd = functools.partial(custom_fwd, device_type="cuda")                            
+custom_bwd = functools.partial(custom_bwd, device_type="cuda")
 
 try:
     from natten import libnatten  # type: ignore


### PR DESCRIPTION
This change gets rid of the many warnings of the type which I paste below:

FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.