### PR TITLE
Support for fused cross-NA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 ## [Main branch]
+* Support for additional KV tokens in FNA (requires xFormers)
+  * Adds experimental support for additional KV tokens (attend to local neighborhood, and some
+  additional context) to FNA interfaces, with training support.
+  * The attention branch between Q and additional KVs runs with xFormers, which targets FAv2.
+  Eventually, we'd want this branch to use PyTorch's SDPA directly, but as of now, there is no
+  SDPA interface that returns logsumexp along with the output, which makes this impossible.
+  * Reduction is done in pure torch, and if possible will be fused into a single op with torch
+  compile.
+  * In theory, any number of different attentions can be merged in this way, but the interface only
+  allows one additional KV set for now.
 
 ## [0.17.3] - 2024-11-01
 * Bug fix for torch < 2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ mypy==1.8.0
 pytest==7.4.4
 click==8.1.7
 rich
+xformers>=0.25.0

--- a/src/natten/__init__.py
+++ b/src/natten/__init__.py
@@ -116,4 +116,4 @@ __all__ = [
     "disable_tiled_na",
 ]
 
-__version__ = "0.17.3"
+__version__ = "0.17.4.dev0"

--- a/tests/test_fna1d.py
+++ b/tests/test_fna1d.py
@@ -64,6 +64,10 @@ def _reset_everything():
     torch.backends.cudnn.benchmark = False
     torch.backends.cuda.matmul.allow_tf32 = False
     torch.backends.cudnn.allow_tf32 = False
+    torch.manual_seed(42)
+
+    # Attention merge recompilation requires this
+    torch._dynamo.config.cache_size_limit = 64
 
 
 HAS_HALF = has_half()
@@ -75,7 +79,16 @@ def check_args(kernel_size, dilation, is_causal):
 
 
 def compute_bmm_reference(
-    B, H, L, D, kernel_size, dilation, has_bias, is_causal=None, dtype=torch.float32
+    B,
+    H,
+    L,
+    D,
+    kernel_size,
+    dilation,
+    has_bias,
+    is_causal=None,
+    dtype=torch.float32,
+    additional_kv_length=0,
 ):
     kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
     assert not has_bias or not any(is_causal)
@@ -84,7 +97,7 @@ def compute_bmm_reference(
             torch.randn((B, H, L, D), device="cuda", dtype=dtype),
             torch.randn((B, H, L, D), device="cuda", dtype=dtype),
             torch.randn((B, H, L, D), device="cuda", dtype=dtype),
-            torch.randn((B, H, L, D), device="cuda", dtype=dtype),
+            torch.randn((B, H, L, D), device="cuda", dtype=dtype) * 0.05,
         )
         rpb = (
             None
@@ -99,11 +112,30 @@ def compute_bmm_reference(
         )
         rpb_ = None if rpb is None else rpb.clone()
 
+        additional_k, additional_v = None, None
+        additional_k_, additional_v_ = None, None
+        if additional_kv_length > 0:
+            additional_k, additional_v = (
+                torch.randn(
+                    (B, H, additional_kv_length, D), device="cuda", dtype=dtype
+                ),
+                torch.randn(
+                    (B, H, additional_kv_length, D), device="cuda", dtype=dtype
+                ),
+            )
+            additional_k_, additional_v_ = (
+                additional_k.clone().permute(0, 2, 1, 3).contiguous(),
+                additional_v.clone().permute(0, 2, 1, 3).contiguous(),
+            )
+
     if rpb is None:
         q = q.requires_grad_(True)
         k = k.requires_grad_(True)
         v = v.requires_grad_(True)
         d_out = d_out.requires_grad_(True)
+        if additional_kv_length > 0:
+            additional_k = additional_k.requires_grad_(True)
+            additional_v = additional_v.requires_grad_(True)
 
     q_scaled = q * (D**-0.5)
     attn_ref = na1d_qk(
@@ -113,6 +145,7 @@ def compute_bmm_reference(
         dilation=dilation,
         is_causal=is_causal,
         rpb=rpb,
+        additional_keys=additional_k,
     )
     attn_ref = attn_ref.softmax(dim=-1)
     out = na1d_av(
@@ -121,10 +154,12 @@ def compute_bmm_reference(
         kernel_size=kernel_size,
         dilation=dilation,
         is_causal=is_causal,
+        additional_values=additional_v,
     )
     with torch.no_grad():
         out_ref = out.clone().permute(0, 2, 1, 3).contiguous()
     dq_ref, dk_ref, dv_ref = None, None, None
+    d_additional_k, d_additional_v = None, None
     if rpb is None:
         out.backward(d_out)
         with torch.no_grad():
@@ -133,11 +168,32 @@ def compute_bmm_reference(
                 k.grad.clone().permute(0, 2, 1, 3).contiguous(),
                 v.grad.clone().permute(0, 2, 1, 3).contiguous(),
             )
-    return (q_, k_, v_, d_out_, rpb_, kernel_size, dilation, is_causal), (
+            if additional_kv_length > 0:
+                d_additional_k = (
+                    additional_k.grad.clone().permute(0, 2, 1, 3).contiguous()
+                )
+                d_additional_v = (
+                    additional_v.grad.clone().permute(0, 2, 1, 3).contiguous()
+                )
+
+    return (
+        q_,
+        k_,
+        v_,
+        d_out_,
+        rpb_,
+        kernel_size,
+        dilation,
+        is_causal,
+        additional_k_,
+        additional_v_,
+    ), (
         out_ref,
         dq_ref,
         dk_ref,
         dv_ref,
+        d_additional_k,
+        d_additional_v,
     )
 
 
@@ -184,19 +240,41 @@ class FNA1DTests(unittest.TestCase):
         _reset_everything()
 
     def _test_against_reference(self, inputs, reference, eps, dtype):
-        q, k, v, d_out, rpb, kernel_size, dilation, is_causal = inputs
+        (
+            q,
+            k,
+            v,
+            d_out,
+            rpb,
+            kernel_size,
+            dilation,
+            is_causal,
+            additional_k,
+            additional_v,
+        ) = inputs
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
-        out_ref, dq_ref, dk_ref, dv_ref = reference
+        out_ref, dq_ref, dk_ref, dv_ref, d_additional_k, d_additional_v = reference
         q_, k_, v_ = q.clone().to(dtype), k.clone().to(dtype), v.clone().to(dtype)
         d_out_ = d_out.clone()
         rpb_ = rpb if rpb is None else rpb.clone().to(dtype)
         assert q_.is_cuda and k_.is_cuda and v_.is_cuda
+
+        has_additional_kv = additional_k is not None and additional_v is not None
+        assert has_additional_kv or (additional_k is None and additional_v is None)
+        additional_k_, additional_v_ = None, None
+        if has_additional_kv:
+            additional_k_, additional_v_ = additional_k.clone().to(
+                dtype
+            ), additional_v.clone().to(dtype)
 
         if rpb is None:
             q_.requires_grad_(True)
             k_.requires_grad_(True)
             v_.requires_grad_(True)
             d_out_.requires_grad_(True)
+            if has_additional_kv:
+                additional_k_.requires_grad_(True)
+                additional_v_.requires_grad_(True)
 
         out = na1d(
             q_,
@@ -206,6 +284,8 @@ class FNA1DTests(unittest.TestCase):
             dilation=dilation,
             is_causal=is_causal,
             rpb=rpb_,
+            additional_keys=additional_k_,
+            additional_values=additional_v_,
         )
 
         torch.testing.assert_close(out.float(), out_ref, atol=eps, rtol=0)
@@ -215,6 +295,14 @@ class FNA1DTests(unittest.TestCase):
             torch.testing.assert_close(q_.grad.float(), dq_ref, atol=eps, rtol=0)
             torch.testing.assert_close(k_.grad.float(), dk_ref, atol=eps, rtol=0)
             torch.testing.assert_close(v_.grad.float(), dv_ref, atol=eps, rtol=0)
+
+            if has_additional_kv:
+                torch.testing.assert_close(
+                    additional_v_.grad.float(), d_additional_v, atol=eps, rtol=0
+                )
+                torch.testing.assert_close(
+                    additional_k_.grad.float(), d_additional_k, atol=eps, rtol=0
+                )
 
     def _test_all_dtypes_against_bmm_style(
         self,
@@ -226,6 +314,7 @@ class FNA1DTests(unittest.TestCase):
         dilation,
         has_bias=False,
         is_causal=None,
+        additional_kv_length=0,
     ):
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
         assert not has_bias or not any(is_causal)
@@ -239,6 +328,7 @@ class FNA1DTests(unittest.TestCase):
             has_bias=has_bias,
             is_causal=is_causal,
             dtype=torch.float32,
+            additional_kv_length=additional_kv_length,
         )
 
         for autotune in [False, True]:
@@ -259,12 +349,14 @@ class FNA1DTests(unittest.TestCase):
             else:
                 use_autotuner(False, False, False, False)
 
-            self._test_against_reference(
-                inputs=inputs,
-                reference=reference,
-                dtype=torch.float32,
-                eps=1e-2,
-            )
+            # xFormers' cutlass backend doesn't support partial attention.
+            if additional_kv_length == 0:
+                self._test_against_reference(
+                    inputs=inputs,
+                    reference=reference,
+                    dtype=torch.float32,
+                    eps=1e-2,
+                )
             if HAS_HALF:
                 self._test_against_reference(
                     inputs=inputs,
@@ -301,16 +393,18 @@ class FNA1DTests(unittest.TestCase):
             (1, 48, 512, 256, 45, 4),
         ]
         for B, H, L, D, kernel_size, dilation in problem_sizes:
-            for is_causal in [False, True]:
-                self._test_all_dtypes_against_bmm_style(
-                    B=B,
-                    H=H,
-                    L=L,
-                    D=D,
-                    kernel_size=kernel_size,
-                    dilation=dilation,
-                    is_causal=is_causal,
-                )
+            for additional_kv_length in [0, 64, L]:
+                for is_causal in [False, True]:
+                    self._test_all_dtypes_against_bmm_style(
+                        B=B,
+                        H=H,
+                        L=L,
+                        D=D,
+                        kernel_size=kernel_size,
+                        dilation=dilation,
+                        is_causal=is_causal,
+                        additional_kv_length=additional_kv_length,
+                    )
             self._test_all_dtypes_against_bmm_style(
                 B=B,
                 H=H,

--- a/tests/test_fna2d.py
+++ b/tests/test_fna2d.py
@@ -65,6 +65,10 @@ def _reset_everything():
     torch.backends.cudnn.benchmark = False
     torch.backends.cuda.matmul.allow_tf32 = False
     torch.backends.cudnn.allow_tf32 = False
+    torch.manual_seed(42)
+
+    # Attention merge recompilation requires this
+    torch._dynamo.config.cache_size_limit = 64
 
 
 HAS_HALF = has_half()
@@ -76,7 +80,17 @@ def check_args(kernel_size, dilation, is_causal):
 
 
 def compute_bmm_reference(
-    B, H, X, Y, D, kernel_size, dilation, has_bias, is_causal=None, dtype=torch.float32
+    B,
+    H,
+    X,
+    Y,
+    D,
+    kernel_size,
+    dilation,
+    has_bias,
+    is_causal=None,
+    dtype=torch.float32,
+    additional_kv_length=0,
 ):
     kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
     assert not has_bias or not any(is_causal)
@@ -85,7 +99,7 @@ def compute_bmm_reference(
             torch.randn((B, H, X, Y, D), device="cuda", dtype=dtype),
             torch.randn((B, H, X, Y, D), device="cuda", dtype=dtype),
             torch.randn((B, H, X, Y, D), device="cuda", dtype=dtype),
-            torch.randn((B, H, X, Y, D), device="cuda", dtype=dtype),
+            torch.randn((B, H, X, Y, D), device="cuda", dtype=dtype) * 0.05,
         )
         rpb = (
             None
@@ -106,11 +120,30 @@ def compute_bmm_reference(
         )
         rpb_ = None if rpb is None else rpb.clone()
 
+        additional_k, additional_v = None, None
+        additional_k_, additional_v_ = None, None
+        if additional_kv_length > 0:
+            additional_k, additional_v = (
+                torch.randn(
+                    (B, H, additional_kv_length, D), device="cuda", dtype=dtype
+                ),
+                torch.randn(
+                    (B, H, additional_kv_length, D), device="cuda", dtype=dtype
+                ),
+            )
+            additional_k_, additional_v_ = (
+                additional_k.clone().permute(0, 2, 1, 3).contiguous(),
+                additional_v.clone().permute(0, 2, 1, 3).contiguous(),
+            )
+
     if rpb is None:
         q = q.requires_grad_(True)
         k = k.requires_grad_(True)
         v = v.requires_grad_(True)
         d_out = d_out.requires_grad_(True)
+        if additional_kv_length > 0:
+            additional_k = additional_k.requires_grad_(True)
+            additional_v = additional_v.requires_grad_(True)
 
     q_scaled = q * (D**-0.5)
     attn_ref = na2d_qk(
@@ -120,6 +153,7 @@ def compute_bmm_reference(
         dilation=dilation,
         is_causal=is_causal,
         rpb=rpb,
+        additional_keys=additional_k,
     )
     attn_ref = attn_ref.softmax(dim=-1)
     out = na2d_av(
@@ -128,10 +162,12 @@ def compute_bmm_reference(
         kernel_size=kernel_size,
         dilation=dilation,
         is_causal=is_causal,
+        additional_values=additional_v,
     )
     with torch.no_grad():
         out_ref = out.clone().permute(0, 2, 3, 1, 4).contiguous()
     dq_ref, dk_ref, dv_ref = None, None, None
+    d_additional_k, d_additional_v = None, None
     if rpb is None:
         out.backward(d_out)
         with torch.no_grad():
@@ -140,11 +176,31 @@ def compute_bmm_reference(
                 k.grad.clone().permute(0, 2, 3, 1, 4).contiguous(),
                 v.grad.clone().permute(0, 2, 3, 1, 4).contiguous(),
             )
-    return (q_, k_, v_, d_out_, rpb_, kernel_size, dilation, is_causal), (
+            if additional_kv_length > 0:
+                d_additional_k = (
+                    additional_k.grad.clone().permute(0, 2, 1, 3).contiguous()
+                )
+                d_additional_v = (
+                    additional_v.grad.clone().permute(0, 2, 1, 3).contiguous()
+                )
+    return (
+        q_,
+        k_,
+        v_,
+        d_out_,
+        rpb_,
+        kernel_size,
+        dilation,
+        is_causal,
+        additional_k_,
+        additional_v_,
+    ), (
         out_ref,
         dq_ref,
         dk_ref,
         dv_ref,
+        d_additional_k,
+        d_additional_v,
     )
 
 
@@ -191,19 +247,41 @@ class FNA2DTests(unittest.TestCase):
         _reset_everything()
 
     def _test_against_reference(self, inputs, reference, eps, dtype):
-        q, k, v, d_out, rpb, kernel_size, dilation, is_causal = inputs
+        (
+            q,
+            k,
+            v,
+            d_out,
+            rpb,
+            kernel_size,
+            dilation,
+            is_causal,
+            additional_k,
+            additional_v,
+        ) = inputs
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
-        out_ref, dq_ref, dk_ref, dv_ref = reference
+        out_ref, dq_ref, dk_ref, dv_ref, d_additional_k, d_additional_v = reference
         q_, k_, v_ = q.clone().to(dtype), k.clone().to(dtype), v.clone().to(dtype)
         d_out_ = d_out.clone()
         rpb_ = rpb if rpb is None else rpb.clone().to(dtype)
         assert q_.is_cuda and k_.is_cuda and v_.is_cuda
+
+        has_additional_kv = additional_k is not None and additional_v is not None
+        assert has_additional_kv or (additional_k is None and additional_v is None)
+        additional_k_, additional_v_ = None, None
+        if has_additional_kv:
+            additional_k_, additional_v_ = additional_k.clone().to(
+                dtype
+            ), additional_v.clone().to(dtype)
 
         if rpb is None:
             q_.requires_grad_(True)
             k_.requires_grad_(True)
             v_.requires_grad_(True)
             d_out_.requires_grad_(True)
+            if has_additional_kv:
+                additional_k_.requires_grad_(True)
+                additional_v_.requires_grad_(True)
 
         out = na2d(
             q_,
@@ -213,6 +291,8 @@ class FNA2DTests(unittest.TestCase):
             dilation=dilation,
             is_causal=is_causal,
             rpb=rpb_,
+            additional_keys=additional_k_,
+            additional_values=additional_v_,
         )
 
         torch.testing.assert_close(out.float(), out_ref, atol=eps, rtol=0)
@@ -222,6 +302,14 @@ class FNA2DTests(unittest.TestCase):
             torch.testing.assert_close(q_.grad.float(), dq_ref, atol=eps, rtol=0)
             torch.testing.assert_close(k_.grad.float(), dk_ref, atol=eps, rtol=0)
             torch.testing.assert_close(v_.grad.float(), dv_ref, atol=eps, rtol=0)
+
+            if has_additional_kv:
+                torch.testing.assert_close(
+                    additional_v_.grad.float(), d_additional_v, atol=eps, rtol=0
+                )
+                torch.testing.assert_close(
+                    additional_k_.grad.float(), d_additional_k, atol=eps, rtol=0
+                )
 
     def _test_all_dtypes_against_bmm_style(
         self,
@@ -234,6 +322,7 @@ class FNA2DTests(unittest.TestCase):
         dilation,
         has_bias=False,
         is_causal=None,
+        additional_kv_length=0,
     ):
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
         assert not has_bias or not any(is_causal)
@@ -248,6 +337,7 @@ class FNA2DTests(unittest.TestCase):
             has_bias=has_bias,
             is_causal=is_causal,
             dtype=torch.float32,
+            additional_kv_length=additional_kv_length,
         )
 
         for autotune in [True, False]:
@@ -264,12 +354,14 @@ class FNA2DTests(unittest.TestCase):
             else:
                 use_autotuner(False, False, False, False)
 
-            self._test_against_reference(
-                inputs=inputs,
-                reference=reference,
-                dtype=torch.float32,
-                eps=1e-2,
-            )
+            # xFormers' cutlass backend doesn't support partial attention.
+            if additional_kv_length == 0:
+                self._test_against_reference(
+                    inputs=inputs,
+                    reference=reference,
+                    dtype=torch.float32,
+                    eps=1e-2,
+                )
             if HAS_HALF:
                 self._test_against_reference(
                     inputs=inputs,
@@ -315,20 +407,22 @@ class FNA2DTests(unittest.TestCase):
             dilation_h,
             dilation_w,
         ) in problem_sizes:
-            for causal_h, causal_w in product([True, False], [True, False]):
-                kernel_size = (kernel_size_h, kernel_size_w)
-                dilation = (dilation_h, dilation_w)
-                is_causal = (causal_h, causal_w)
-                self._test_all_dtypes_against_bmm_style(
-                    B=B,
-                    H=H,
-                    X=X,
-                    Y=Y,
-                    D=D,
-                    kernel_size=kernel_size,
-                    dilation=dilation,
-                    is_causal=is_causal,
-                )
+            for additional_kv_length in [0, 64]:
+                for causal_h, causal_w in product([True, False], [True, False]):
+                    kernel_size = (kernel_size_h, kernel_size_w)
+                    dilation = (dilation_h, dilation_w)
+                    is_causal = (causal_h, causal_w)
+                    self._test_all_dtypes_against_bmm_style(
+                        B=B,
+                        H=H,
+                        X=X,
+                        Y=Y,
+                        D=D,
+                        kernel_size=kernel_size,
+                        dilation=dilation,
+                        is_causal=is_causal,
+                        additional_kv_length=additional_kv_length,
+                    )
             self._test_all_dtypes_against_bmm_style(
                 B=B,
                 H=H,

--- a/tools/profile_1d.py
+++ b/tools/profile_1d.py
@@ -55,6 +55,7 @@ from utils import (
 @click.option("--fmha", is_flag=True)
 @click.option("--fav2", is_flag=True)
 @click.option("--backprop", is_flag=True)
+@click.option("--add-kv", default=0)
 def profile_1d(
     batch_size: int,
     heads: int,
@@ -74,6 +75,7 @@ def profile_1d(
     fmha: bool,
     fav2: bool,
     backprop: bool,
+    add_kv: int,
 ):
 
     dtype = torch.float32
@@ -112,6 +114,8 @@ def profile_1d(
         dilation=dilation,
         dtype=dtype,
         has_bias=bias,
+        is_causal=causal,
+        additional_kv_length=add_kv,
     )
     logged_ops = func(
         problem=problem,

--- a/tools/profile_2d.py
+++ b/tools/profile_2d.py
@@ -57,6 +57,7 @@ from utils import (
 @click.option("--fmha", is_flag=True)
 @click.option("--fav2", is_flag=True)
 @click.option("--backprop", is_flag=True)
+@click.option("--add-kv", default=0)
 def profile_2d(
     batch_size: int,
     heads: int,
@@ -78,6 +79,7 @@ def profile_2d(
     fmha: bool,
     fav2: bool,
     backprop: bool,
+    add_kv: int,
 ):
 
     dtype = torch.float32
@@ -120,6 +122,7 @@ def profile_2d(
         dtype=dtype,
         has_bias=bias,
         is_causal=causal,
+        additional_kv_length=add_kv,
     )
     logged_ops = func(
         problem=problem,

--- a/tools/profile_3d.py
+++ b/tools/profile_3d.py
@@ -48,12 +48,14 @@ from utils import (
 @click.option("--fp16", is_flag=True)
 @click.option("--bf16", is_flag=True)
 @click.option("--bias", is_flag=True)
+@click.option("--causal", is_flag=True)
 @click.option("--disable-autotuner", is_flag=True)
 @click.option("--warmup-steps", default=10)
 @click.option("--fuse", is_flag=True)
 @click.option("--fmha", is_flag=True)
 @click.option("--fav2", is_flag=True)
 @click.option("--backprop", is_flag=True)
+@click.option("--add-kv", default=0)
 def profile_3d(
     batch_size: int,
     heads: int,
@@ -66,12 +68,14 @@ def profile_3d(
     fp16: bool,
     bf16: bool,
     bias: bool,
+    causal: bool,
     disable_autotuner: bool,
     warmup_steps: int,
     fuse: bool,
     fmha: bool,
     fav2: bool,
     backprop: bool,
+    add_kv: int,
 ):
 
     dtype = torch.float32
@@ -107,6 +111,8 @@ def profile_3d(
         dilation=dilation,
         dtype=dtype,
         has_bias=bias,
+        is_causal=causal,
+        additional_kv_length=add_kv,
     )
     logged_ops = func(
         problem=problem,

--- a/tools/utils/problem.py
+++ b/tools/utils/problem.py
@@ -42,6 +42,7 @@ class Problem:
         dtype: Any,
         has_bias: bool,
         is_causal: CausalType = None,
+        additional_kv_length: Optional[int] = None,
     ):
         self.na_dim = na_dim
         self.batch_size = batch_size
@@ -54,6 +55,16 @@ class Problem:
         self.dtype = dtype
         self.has_bias = has_bias
         self.is_causal = is_causal or [False for _ in range(na_dim)]
+        self.has_additional_kv = (
+            additional_kv_length is not None and additional_kv_length > 0
+        )
+        self.additional_kv_length = additional_kv_length
+
+    def get_additional_kv_shape(self, fused_layout: bool) -> List:
+        assert self.additional_kv_length is not None
+        if not fused_layout:
+            return [self.batch_size, self.heads, self.additional_kv_length, self.dim]
+        return [self.batch_size, self.additional_kv_length, self.heads, self.dim]
 
     def get_tensor_shape(self, fused_layout: bool) -> List:
         if not fused_layout:
@@ -107,6 +118,7 @@ def generate_1d_problem(
     dtype: Any,
     has_bias: bool,
     is_causal: CausalType = None,
+    additional_kv_length: Optional[int] = None,
 ) -> Problem:
     return Problem(
         na_dim=1,
@@ -119,6 +131,7 @@ def generate_1d_problem(
         dtype=dtype,
         has_bias=has_bias,
         is_causal=is_causal,
+        additional_kv_length=additional_kv_length,
     )
 
 
@@ -133,6 +146,7 @@ def generate_2d_problem(
     dtype: Any,
     has_bias: bool,
     is_causal: CausalType = None,
+    additional_kv_length: Optional[int] = None,
 ) -> Problem:
     return Problem(
         na_dim=2,
@@ -145,6 +159,7 @@ def generate_2d_problem(
         dtype=dtype,
         has_bias=has_bias,
         is_causal=is_causal,
+        additional_kv_length=additional_kv_length,
     )
 
 
@@ -160,6 +175,7 @@ def generate_3d_problem(
     dtype: Any,
     has_bias: bool,
     is_causal: CausalType = None,
+    additional_kv_length: Optional[int] = None,
 ) -> Problem:
     return Problem(
         na_dim=3,
@@ -172,4 +188,5 @@ def generate_3d_problem(
         dtype=dtype,
         has_bias=has_bias,
         is_causal=is_causal,
+        additional_kv_length=additional_kv_length,
     )


### PR DESCRIPTION
Adds experimental support for additional context tokens to Fused NA.

Any number of partial attention results can be reduced into a final one as if their contexts were merged, which is just the same implications from Online Softmax that made Flash Attention possible. This is already being used in production for CP anyway, so it's relatively trivial to do it within NATTEN.

The cross attention should ideally target torch's SDPA, but there's currently no interface for doind SDPA and getting LSE back, which is why we have to rely on xFormers for that.

More details coming soon.

Addresses #132.