### PR TITLE
Experimental interface for torch ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Bug fixes in FLOP counter (with fvcore)
   * Bugs introduced since FNA backwards were fixed.
   * Finally added unit tests.
+* Better FLOP counting support
+  * Rename instances of FLOP counting with fvcore to MACs, since that's what fvcore reports.
+  * Add experimental support for torch's native flop counter
+  * Better documentation
 
 ## [0.17.3] - 2024-11-01
 * Bug fix for torch < 2.4

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Welcome to NATTEN docs!
   * Describes how to check NATTEN's compatibility with your system, and its available features.
   * Describes how to use torch modules `NeighborhoodAttention1D`, `NeighborhoodAttention2D`, and `NeighborhoodAttention3D`.
   * Describes when and how to use ops directly instead of modules.
+* [FLOP counting](flops.md)
 * [Fused Neighborhood Attention](fna/) (new)
   * [Quick start guide](fna/fna-quickstart.md)
   * [Fused vs unfused](fna/fused-vs-unfused.md): differences in supported features, layouts, etc.

--- a/docs/flops.md
+++ b/docs/flops.md
@@ -38,9 +38,9 @@ the entire attention operator all at once, use `fna_flop_count`:
 
 ```python
 fna_flop_count(
-    q_shape: torch.Size | Sequence[int] | List[int],
-    k_shape: torch.Size | Sequence[int] | List[int],
-    v_shape: torch.Size | Sequence[int] | List[int],
+    q_shape: torch.Size | Sequence[int],
+    k_shape: torch.Size | Sequence[int],
+    v_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -62,8 +62,8 @@ weighting operations separately, use `na_qk_flop_count` and `na_av_flop_count`:
 
 ```python
 na_qk_flop_count(
-    q_shape: torch.Size | Sequence[int] | List[int],
-    k_shape: torch.Size | Sequence[int] | List[int],
+    q_shape: torch.Size | Sequence[int],
+    k_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -72,8 +72,8 @@ na_qk_flop_count(
 ) -> int
 
 na_av_flop_count(
-    a_shape: torch.Size | Sequence[int] | List[int],
-    v_shape: torch.Size | Sequence[int] | List[int],
+    a_shape: torch.Size | Sequence[int],
+    v_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],

--- a/docs/flops.md
+++ b/docs/flops.md
@@ -101,37 +101,33 @@ More details in #170.
 
 In the meantime, we offer an experimental interface for NATTEN ops registered with torch.library,
 which only supports inference, and only implements FNA operations.
-Instead of using the `na*d` operations from `natten.functional` or our torch modules
-(`NeighborhoodAttention*D`), you will need to use the `na*d` operations from `natten.experimental`:
+Instead of using the `na*d` operations from `natten.functional` you will need to use the `na*d`
+operations from `natten.experimental`:
 
 
 ```python
 # from natten.functional import na1d, na2d, na3d
 from natten.experimental import na1d, na2d, na3d
-
-# ...
-
-class Attention1D(torch.nn.Module):
-  # ...
-  def forward(...):
-    # ...
-    x = na1d(...)
-    # ...
-
-class Attention2D(torch.nn.Module):
-  # ...
-  def forward(...):
-    # ...
-    x = na2d(...)
-    # ...
-
-class Attention3D(torch.nn.Module):
-  # ...
-  def forward(...):
-    # ...
-    x = na3d(...)
-    # ...
 ```
+
+or if you're using NATTEN's torch modules (`NeighborhoodAttention*D`), you need to pass an
+additional argument:
+
+```python
+from natten import (
+  NeighborhoodAttention1D,
+  NeighborhoodAttention2D
+  NeighborhoodAttention3D
+)
+
+m_1d = NeighborhoodAttention1D(dim=128, num_heads=4, kernel_size=7, use_experimental_ops=True)
+m_2d = NeighborhoodAttention2D(dim=128, num_heads=4, kernel_size=7, use_experimental_ops=True)
+m_3d = NeighborhoodAttention3D(dim=128, num_heads=4, kernel_size=7, use_experimental_ops=True)
+```
+
+However, note that forward pass will fail if fused NA is disabled / not supported, but using
+experimental ops is enabled.
+
 
 As long as you use these experimental ops, you can:
 * Successfully build NA-based models with `torch.compile` WITHOUT graph breaks,

--- a/docs/flops.md
+++ b/docs/flops.md
@@ -1,0 +1,192 @@
+## FLOP counting with NATTEN
+
+NATTEN offers multiple solutions for counting FLOPs/MACs.
+
+However, note that due to the variety of solutions available for this, it is important to have a
+consistent definitions of FLOPs and how they are counted.
+
+### Rules
+Since NATTEN is limited to the dot product attention operator, here we note the general rules for
+counting FLOPs/MACs in NATTEN:
+
+Following standard practice, only Tensor Core (TC) FLOPs are counted.
+Softmax, masking, attention scale, and positional biases are NOT included in the FLOP/MAC count.
+
+For a GEMM problem with shape `(M, N, K)`, MACs (Multiply-and-Accumulate operations) is simply
+`M * N * K`, while FLOPs (Floating Point Operations) considers multiply and accumulate separate
+operations, and ends up being `2 * M * N * K`.
+
+Causal masking also does **not** affect FLOPs/MACs today, but this behavior may change in the
+future. It makes sense to measure in causal masking for various reasons, but the actual FLOP
+decrease is not so granular in practice. More details will be added about this in the future.
+Please refer to [#184](https://github.com/SHI-Labs/NATTEN/issues/184#issuecomment-2505022903) for
+more information.
+
+### Manual
+All users can integrate NATTEN's FLOP/MAC counting logic into their own FLOP counting logic:
+
+```python
+from natten.flops import (
+  fna_flop_count,
+  na_qk_flop_count,
+  na_av_flop_count
+)
+```
+
+If you're using [Fused Neighborhood Attention (FNA)](fna/), or just prefer to compute FLOPs/MACs for
+the entire attention operator all at once, use `fna_flop_count`:
+
+```python
+fna_flop_count(
+    q_shape: torch.Size | Sequence[int] | List[int],
+    k_shape: torch.Size | Sequence[int] | List[int],
+    v_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False
+) -> int
+```
+
+Simply pass the shape of your QKV tensors, and NA-related arguments (`kernel_size`, `dilation`,
+`is_causal` as tuples), and finally, two key arguments:
+* `is_heads_last`: determines your QKV tensor layout. If `True`, your QKV is expected to assume the
+  layout `[batch, *, heads, dim_per_head]`, and otherwise, `[batch, heads, *, dim_per_head`.
+  NOTE: Fused ops in NATTEN (FNA) currently use the "heads last" layout, so be sure to pass `True`
+  for them. Unfused ops in NATTEN use the "heads first" layout.
+* `return_macs`: If `True`, returns MACs instead of FLOPs. Please be very careful when setting this.
+
+If you're using unfused implementations, or prefer to compute FLOPs/MACs for the dot product and
+weighting operations separately, use `na_qk_flop_count` and `na_av_flop_count`:
+
+```python
+na_qk_flop_count(
+    q_shape: torch.Size | Sequence[int] | List[int],
+    k_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> int
+
+na_av_flop_count(
+    a_shape: torch.Size | Sequence[int] | List[int],
+    v_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> int
+```
+
+The APIs are mostly similar to the fused variant, and you need to pay extra attention to setting
+`is_heads_last` and `return_macs`.
+
+### PyTorch (>= 2.4.0)
+
+PyTorch itself now supports counting model FLOPs, but obviously models with custom operators would
+require extra work and `torch >= 2.4.0`.
+
+**NOTE:** PyTorch reports FLOPs, not MACs!
+
+PyTorch only counts FLOPs based on operations registered with torch.library. This excludes autograd
+functions, which historically have been the only choice for binding custom operators to PyTorch and
+getting autograd support.
+NATTEN will eventually migrate to registering with torch.library, but that process is on hold until
+certain features available in autograd functions are supported in the new API.
+More details in #170.
+
+In the meantime, we offer an experimental interface for NATTEN ops registered with torch.library,
+which only supports inference, and only implements FNA operations.
+Instead of using the `na*d` operations from `natten.functional` or our torch modules
+(`NeighborhoodAttention*D`), you will need to use the `na*d` operations from `natten.experimental`:
+
+
+```python
+# from natten.functional import na1d, na2d, na3d
+from natten.experimental import na1d, na2d, na3d
+
+# ...
+
+class Attention1D(torch.nn.Module):
+  # ...
+  def forward(...):
+    # ...
+    x = na1d(...)
+    # ...
+
+class Attention2D(torch.nn.Module):
+  # ...
+  def forward(...):
+    # ...
+    x = na2d(...)
+    # ...
+
+class Attention3D(torch.nn.Module):
+  # ...
+  def forward(...):
+    # ...
+    x = na3d(...)
+    # ...
+```
+
+As long as you use these experimental ops, you can:
+* Successfully build NA-based models with `torch.compile` WITHOUT graph breaks,
+* Count flops with `torch.utils.flops`
+
+For more information on the `na*d` interface, please refer to our [frontend docs](frontend.md) or
+[Fused Neighborhood Attention docs](fna/).
+
+To count FLOPs with PyTorch's native FLOP counter:
+
+```python
+from torch.utils.flop_counter import FlopCounterMode
+
+flop_counter = FlopCounterMode()
+
+with flop_counter:
+  y = model_with_natten_ops(x)
+
+total_flops = flop_counter.get_total_flops()
+```
+
+**NOTE:** 
+
+### FVCore
+
+NATTEN can be paired with [fvcore](https://github.com/facebookresearch/fvcore)'s counter, as long as you correctly
+import and add NATTEN's handles to the counter.
+
+The only requirement is having fvcore installed.
+
+**NOTE:** fvocre reports MACs, not FLOPs!
+
+```python
+from fvcore.nn import FlopCountAnalysis
+from natten.flops import add_natten_handle
+
+# ...
+
+flop_ctr = FlopCountAnalysis(model, input)
+flop_ctr = add_natten_handle(flop_ctr)
+
+# ...
+```
+
+Alternatively, you can use our `get_flops` interface and count FLOPs for a model that may contain
+NATTEN ops/modules:
+```python
+from natten.flops import get_flops
+
+flops = get_flops(model, input)
+```
+
+#### Installing fvcore
+fvcore is available through PyPI:
+
+```shell
+pip install fvcore
+```

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -417,34 +417,5 @@ disable_tiled_na()
 enable_tiled_na()
 ```
 
-### FLOP counting with FVCore
-
-NATTEN can be paired with [fvcore](https://github.com/facebookresearch/fvcore)'s FLOP counter, as long as you correctly
-import and add NATTEN's handles to the flop counter.
-
-```python
-from fvcore.nn import FlopCountAnalysis
-from natten.flops import add_natten_handle
-
-# ...
-
-flop_ctr = FlopCountAnalysis(model, input)
-flop_ctr = add_natten_handle(flop_ctr)
-
-# ...
-```
-
-Alternatively, you can use our `get_flops` interface and count FLOPs for a model that may contain
-NATTEN ops/modules:
-```python
-from natten.flops import get_flops
-
-flops = get_flops(model, input)
-```
-
-#### Installing fvcore
-fvcore is available through PyPI:
-
-```shell
-pip install fvcore
-```
+### Counting FLOPs
+Please refer to our [FLOP counting guide](flops.md) for more information.

--- a/src/natten/experimental.py
+++ b/src/natten/experimental.py
@@ -1,0 +1,491 @@
+#################################################################################################
+# Copyright (c) 2022-2024 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+from typing import Dict, Optional, Sequence, Tuple
+
+import torch
+from torch import Tensor
+
+try:
+    from natten import libnatten  # type: ignore
+except ImportError:
+    raise ImportError(
+        "Failed to import libnatten. "
+        "This could be due to an invalid/incomplete install. "
+        "Please make sure you built NATTEN correctly, or refer to "
+        "https://shi-labs.com/natten for more information."
+    )
+
+torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
+if torch_ver < [2, 4]:
+    raise NotImplementedError(
+        "NATTEN's experimental interface is written for torch >= 2.4, "
+        f"your torch version: {torch.__version__}."
+    )
+
+from .autotuner.fna_forward import get_default_tiling_config_for_fna_forward
+from .ops import additional_sdpa, merge_attentions
+
+from .types import (
+    CausalArg1DTypeOrDed,
+    CausalArg2DTypeOrDed,
+    CausalArg3DTypeOrDed,
+    Dimension1DTypeOrDed,
+    Dimension2DTypeOrDed,
+    Dimension3DTypeOrDed,
+)
+
+from .utils import check_all_args, check_tiling_config, log
+
+logger = log.get_logger(__name__)
+
+
+#################################################################################################
+##################################### Register forward ops. #####################################
+#################################################################################################
+
+
+@torch.library.custom_op(
+    "natten::na1d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
+)
+def na1d_torch_library_op(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    kernel_size, dilation, is_causal = check_all_args(
+        1, kernel_size_, dilation_, is_causal_
+    )
+
+    assert isinstance(
+        scale, float
+    ), f"Expected float attention scale, got {type(scale)}."
+
+    (q_tiler, kv_tiler) = check_tiling_config(1, (q_tiler_, kv_tiler_))
+
+    if any(is_causal) and bias is not None:
+        raise NotImplementedError(
+            "Positional biases for causal neighborhood attention is not yet implemented."
+        )
+
+    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+    # and instead indicate they require contiguous operands.
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    if bias is not None:
+        bias = bias.to(query.dtype).contiguous()
+    output = torch.empty_like(value)
+
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+
+    libnatten.na1d_forward(
+        output,
+        query,
+        key,
+        value,
+        bias,
+        logsumexp,
+        kernel_size,
+        dilation,
+        is_causal,
+        scale,
+        q_tiler,
+        kv_tiler,
+    )
+
+    return output, logsumexp
+
+
+@torch.library.custom_op(
+    "natten::na2d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
+)
+def na2d_torch_library_op(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    kernel_size, dilation, is_causal = check_all_args(
+        2, kernel_size_, dilation_, is_causal_
+    )
+
+    assert isinstance(
+        scale, float
+    ), f"Expected float attention scale, got {type(scale)}."
+
+    (q_tiler, kv_tiler) = check_tiling_config(2, (q_tiler_, kv_tiler_))
+
+    if any(is_causal) and bias is not None:
+        raise NotImplementedError(
+            "Positional biases for causal neighborhood attention is not yet implemented."
+        )
+
+    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+    # and instead indicate they require contiguous operands.
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    if bias is not None:
+        bias = bias.to(query.dtype).contiguous()
+    output = torch.empty_like(value)
+
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+
+    libnatten.na2d_forward(
+        output,
+        query,
+        key,
+        value,
+        bias,
+        logsumexp,
+        kernel_size,
+        dilation,
+        is_causal,
+        scale,
+        q_tiler,
+        kv_tiler,
+    )
+
+    return output, logsumexp
+
+
+@torch.library.custom_op(
+    "natten::na3d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
+)
+def na3d_torch_library_op(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    kernel_size, dilation, is_causal = check_all_args(
+        3, kernel_size_, dilation_, is_causal_
+    )
+
+    assert isinstance(
+        scale, float
+    ), f"Expected float attention scale, got {type(scale)}."
+
+    (q_tiler, kv_tiler) = check_tiling_config(3, (q_tiler_, kv_tiler_))
+
+    if any(is_causal) and bias is not None:
+        raise NotImplementedError(
+            "Positional biases for causal neighborhood attention is not yet implemented."
+        )
+
+    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+    # and instead indicate they require contiguous operands.
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    if bias is not None:
+        bias = bias.to(query.dtype).contiguous()
+    output = torch.empty_like(value)
+
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+
+    libnatten.na3d_forward(
+        output,
+        query,
+        key,
+        value,
+        bias,
+        logsumexp,
+        kernel_size,
+        dilation,
+        is_causal,
+        scale,
+        q_tiler,
+        kv_tiler,
+    )
+
+    return output, logsumexp
+
+
+#################################################################################################
+################## Register "fake" ops for forward op, since it's not inplace. ##################
+#################################################################################################
+
+
+@na1d_torch_library_op.register_fake
+def na1d_op_fake(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    output = torch.empty_like(value)
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+    return output, logsumexp
+
+
+@na2d_torch_library_op.register_fake
+def na2d_op_fake(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    output = torch.empty_like(value)
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+    return output, logsumexp
+
+
+@na3d_torch_library_op.register_fake
+def na3d_op_fake(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    bias: Optional[Tensor],
+    kernel_size_: Sequence[int],
+    dilation_: Sequence[int],
+    is_causal_: Sequence[bool],
+    scale: float,
+    q_tiler_: Sequence[int],
+    kv_tiler_: Sequence[int],
+) -> Tuple[Tensor, Tensor]:
+    output = torch.empty_like(value)
+    # TODO: logsumexp should be conditional
+    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+    return output, logsumexp
+
+
+#################################################################################################
+######################################## User-facing APIs #######################################
+#################################################################################################
+
+
+def na1d(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension1DTypeOrDed,
+    dilation: Dimension1DTypeOrDed = 1,
+    is_causal: Optional[CausalArg1DTypeOrDed] = False,
+    rpb: Optional[Tensor] = None,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    xformers_kwargs: Optional[Dict] = None,
+) -> Tensor:
+    if query.is_nested or key.is_nested or value.is_nested:
+        raise NotImplementedError(
+            "Fused neighborhood attention does not support nested tensors yet."
+        )
+
+    kernel_size_, dilation_, is_causal_ = check_all_args(
+        1, kernel_size, dilation, is_causal
+    )
+    # TODO: autotuner and torch compile aren't supported together
+    tiling_config_forward = get_default_tiling_config_for_fna_forward(
+        1, input_tensor=query, dilation=dilation_
+    )
+
+    scale = scale or query.shape[-1] ** -0.5
+
+    output, lse = na1d_torch_library_op(
+        query,
+        key,
+        value,
+        rpb,
+        kernel_size_,
+        dilation_,
+        is_causal_,
+        scale,
+        *tiling_config_forward,
+    )
+
+    if additional_keys is not None and additional_values is not None:
+        if additional_keys is None or additional_values is None:
+            raise ValueError(
+                "Both `additional_keys` and `additional_values` must be "
+                "either Tensors or NoneTypes."
+            )
+
+        additional_output, additional_lse = additional_sdpa(
+            query,
+            additional_keys,
+            additional_values,
+            scale=scale,
+            attn_kwargs=xformers_kwargs,
+        )
+
+        return merge_attentions(output, additional_output, lse, additional_lse)
+
+    return output
+
+
+def na2d(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension2DTypeOrDed,
+    dilation: Dimension2DTypeOrDed = 1,
+    is_causal: Optional[CausalArg2DTypeOrDed] = False,
+    rpb: Optional[Tensor] = None,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    xformers_kwargs: Optional[Dict] = None,
+) -> Tensor:
+    if query.is_nested or key.is_nested or value.is_nested:
+        raise NotImplementedError(
+            "Fused neighborhood attention does not support nested tensors yet."
+        )
+
+    kernel_size_, dilation_, is_causal_ = check_all_args(
+        2, kernel_size, dilation, is_causal
+    )
+    # TODO: autotuner and torch compile aren't supported together
+    tiling_config_forward = get_default_tiling_config_for_fna_forward(
+        2, input_tensor=query, dilation=dilation_
+    )
+
+    scale = scale or query.shape[-1] ** -0.5
+
+    output, lse = na2d_torch_library_op(
+        query,
+        key,
+        value,
+        rpb,
+        kernel_size_,
+        dilation_,
+        is_causal_,
+        scale,
+        *tiling_config_forward,
+    )
+
+    if additional_keys is not None and additional_values is not None:
+        if additional_keys is None or additional_values is None:
+            raise ValueError(
+                "Both `additional_keys` and `additional_values` must be "
+                "either Tensors or NoneTypes."
+            )
+
+        additional_output, additional_lse = additional_sdpa(
+            query,
+            additional_keys,
+            additional_values,
+            scale=scale,
+            attn_kwargs=xformers_kwargs,
+        )
+
+        return merge_attentions(output, additional_output, lse, additional_lse)
+
+    return output
+
+
+def na3d(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension3DTypeOrDed,
+    dilation: Dimension3DTypeOrDed = 1,
+    is_causal: Optional[CausalArg3DTypeOrDed] = False,
+    rpb: Optional[Tensor] = None,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    xformers_kwargs: Optional[Dict] = None,
+) -> Tensor:
+    if query.is_nested or key.is_nested or value.is_nested:
+        raise NotImplementedError(
+            "Fused neighborhood attention does not support nested tensors yet."
+        )
+
+    kernel_size_, dilation_, is_causal_ = check_all_args(
+        3, kernel_size, dilation, is_causal
+    )
+    # TODO: autotuner and torch compile aren't supported together
+    tiling_config_forward = get_default_tiling_config_for_fna_forward(
+        3, input_tensor=query, dilation=dilation_
+    )
+
+    scale = scale or query.shape[-1] ** -0.5
+
+    output, lse = na3d_torch_library_op(
+        query,
+        key,
+        value,
+        rpb,
+        kernel_size_,
+        dilation_,
+        is_causal_,
+        scale,
+        *tiling_config_forward,
+    )
+
+    if additional_keys is not None and additional_values is not None:
+        if additional_keys is None or additional_values is None:
+            raise ValueError(
+                "Both `additional_keys` and `additional_values` must be "
+                "either Tensors or NoneTypes."
+            )
+
+        additional_output, additional_lse = additional_sdpa(
+            query,
+            additional_keys,
+            additional_values,
+            scale=scale,
+            attn_kwargs=xformers_kwargs,
+        )
+
+        return merge_attentions(output, additional_output, lse, additional_lse)
+
+    return output

--- a/src/natten/experimental.py
+++ b/src/natten/experimental.py
@@ -24,31 +24,6 @@ from typing import Any, Dict, Optional, Protocol, Sequence, Tuple
 
 import torch
 from torch import Size, Tensor
-from torch._ops import OpOverloadPacket
-from torch.utils.flop_counter import register_flop_formula
-
-try:
-    from natten import libnatten  # type: ignore
-except ImportError:
-    raise ImportError(
-        "Failed to import libnatten. "
-        "This could be due to an invalid/incomplete install. "
-        "Please make sure you built NATTEN correctly, or refer to "
-        "https://shi-labs.com/natten for more information."
-    )
-
-torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-if torch_ver < [2, 4]:
-    raise NotImplementedError(
-        "NATTEN's experimental interface is written for torch >= 2.4, "
-        f"your torch version: {torch.__version__}."
-    )
-
-from .autotuner.fna_forward import get_default_tiling_config_for_fna_forward
-
-from .flops import fna_flop_count
-
-from .ops import additional_sdpa, merge_attentions
 
 from .types import (
     CausalArg1DTypeOrDed,
@@ -59,533 +34,606 @@ from .types import (
     Dimension3DTypeOrDed,
 )
 
-from .utils import check_all_args, check_tiling_config, log
+from .utils import log
 
 logger = log.get_logger(__name__)
 
+torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
+if torch_ver < [2, 4]:
 
-#################################################################################################
-##################################### Register forward ops. #####################################
-#################################################################################################
-
-
-@torch.library.custom_op(
-    "natten::na1d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
-)
-def na1d_torch_library_op(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    kernel_size, dilation, is_causal = check_all_args(
-        1, kernel_size_, dilation_, is_causal_
-    )
-
-    assert isinstance(
-        scale, float
-    ), f"Expected float attention scale, got {type(scale)}."
-
-    (q_tiler, kv_tiler) = check_tiling_config(1, (q_tiler_, kv_tiler_))
-
-    if any(is_causal) and bias is not None:
+    def na1d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension1DTypeOrDed,
+        dilation: Dimension1DTypeOrDed = 1,
+        is_causal: Optional[CausalArg1DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
         raise NotImplementedError(
-            "Positional biases for causal neighborhood attention is not yet implemented."
+            "NATTEN's experimental interface is written for torch >= 2.4, "
+            f"your torch version: {torch.__version__}."
         )
 
-    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
-    # and instead indicate they require contiguous operands.
-    query = query.contiguous()
-    key = key.contiguous()
-    value = value.contiguous()
-    if bias is not None:
-        bias = bias.to(query.dtype).contiguous()
-    output = torch.empty_like(value)
-
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
-
-    libnatten.na1d_forward(
-        output,
-        query,
-        key,
-        value,
-        bias,
-        logsumexp,
-        kernel_size,
-        dilation,
-        is_causal,
-        scale,
-        q_tiler,
-        kv_tiler,
-    )
-
-    return output, logsumexp
-
-
-@torch.library.custom_op(
-    "natten::na2d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
-)
-def na2d_torch_library_op(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    kernel_size, dilation, is_causal = check_all_args(
-        2, kernel_size_, dilation_, is_causal_
-    )
-
-    assert isinstance(
-        scale, float
-    ), f"Expected float attention scale, got {type(scale)}."
-
-    (q_tiler, kv_tiler) = check_tiling_config(2, (q_tiler_, kv_tiler_))
-
-    if any(is_causal) and bias is not None:
+    def na2d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension2DTypeOrDed,
+        dilation: Dimension2DTypeOrDed = 1,
+        is_causal: Optional[CausalArg2DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
         raise NotImplementedError(
-            "Positional biases for causal neighborhood attention is not yet implemented."
+            "NATTEN's experimental interface is written for torch >= 2.4, "
+            f"your torch version: {torch.__version__}."
         )
 
-    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
-    # and instead indicate they require contiguous operands.
-    query = query.contiguous()
-    key = key.contiguous()
-    value = value.contiguous()
-    if bias is not None:
-        bias = bias.to(query.dtype).contiguous()
-    output = torch.empty_like(value)
-
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
-
-    libnatten.na2d_forward(
-        output,
-        query,
-        key,
-        value,
-        bias,
-        logsumexp,
-        kernel_size,
-        dilation,
-        is_causal,
-        scale,
-        q_tiler,
-        kv_tiler,
-    )
-
-    return output, logsumexp
-
-
-@torch.library.custom_op(
-    "natten::na3d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
-)
-def na3d_torch_library_op(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    kernel_size, dilation, is_causal = check_all_args(
-        3, kernel_size_, dilation_, is_causal_
-    )
-
-    assert isinstance(
-        scale, float
-    ), f"Expected float attention scale, got {type(scale)}."
-
-    (q_tiler, kv_tiler) = check_tiling_config(3, (q_tiler_, kv_tiler_))
-
-    if any(is_causal) and bias is not None:
+    def na3d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension3DTypeOrDed,
+        dilation: Dimension3DTypeOrDed = 1,
+        is_causal: Optional[CausalArg3DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
         raise NotImplementedError(
-            "Positional biases for causal neighborhood attention is not yet implemented."
+            "NATTEN's experimental interface is written for torch >= 2.4, "
+            f"your torch version: {torch.__version__}."
         )
 
-    # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
-    # and instead indicate they require contiguous operands.
-    query = query.contiguous()
-    key = key.contiguous()
-    value = value.contiguous()
-    if bias is not None:
-        bias = bias.to(query.dtype).contiguous()
-    output = torch.empty_like(value)
+else:
+    from torch._ops import OpOverloadPacket
+    from torch.utils.flop_counter import register_flop_formula
 
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
+    from .autotuner.fna_forward import get_default_tiling_config_for_fna_forward
 
-    libnatten.na3d_forward(
-        output,
-        query,
-        key,
-        value,
-        bias,
-        logsumexp,
-        kernel_size,
-        dilation,
-        is_causal,
-        scale,
-        q_tiler,
-        kv_tiler,
-    )
+    from .flops import fna_flop_count
 
-    return output, logsumexp
+    from .ops import additional_sdpa, merge_attentions
 
+    from .utils import check_all_args, check_tiling_config
 
-#################################################################################################
-################## Register "fake" ops for forward op, since it's not inplace. ##################
-#################################################################################################
-
-
-@na1d_torch_library_op.register_fake
-def na1d_op_fake(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    output = torch.empty_like(value)
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
-    return output, logsumexp
-
-
-@na2d_torch_library_op.register_fake
-def na2d_op_fake(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    output = torch.empty_like(value)
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
-    return output, logsumexp
-
-
-@na3d_torch_library_op.register_fake
-def na3d_op_fake(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    bias: Optional[Tensor],
-    kernel_size_: Sequence[int],
-    dilation_: Sequence[int],
-    is_causal_: Sequence[bool],
-    scale: float,
-    q_tiler_: Sequence[int],
-    kv_tiler_: Sequence[int],
-) -> Tuple[Tensor, Tensor]:
-    output = torch.empty_like(value)
-    # TODO: logsumexp should be conditional
-    logsumexp = torch.empty(query.shape[:-1], dtype=torch.float32, device=query.device)
-    return output, logsumexp
-
-
-#################################################################################################
-########################################### FLOP Counts #########################################
-#################################################################################################
-
-
-class FlopCountFn(Protocol):
-    @staticmethod
-    def __call__(*args, **kwargs) -> int: ...
-
-
-@register_flop_formula(torch.ops.natten.na1d_forward_op)
-def na1d_flop_count(
-    q_shape: Size,
-    k_shape: Size,
-    v_shape: Size,
-    bias: Optional[Tensor],
-    kernel_size: Sequence[int],
-    dilation: Sequence[int],
-    is_causal: Sequence[bool],
-    scale: float,
-    q_tiler: Sequence[int],
-    kv_tiler: Sequence[int],
-    out_shape: Any,
-):
-    return fna_flop_count(
-        q_shape=q_shape,
-        k_shape=k_shape,
-        v_shape=v_shape,
-        kernel_size=kernel_size,
-        dilation=dilation,
-        is_causal=is_causal,
-        is_heads_last=True,
-        return_macs=False,
-    )
-
-
-@register_flop_formula(torch.ops.natten.na2d_forward_op)
-def na2d_flop_count(
-    q_shape: Size,
-    k_shape: Size,
-    v_shape: Size,
-    bias: Optional[Tensor],
-    kernel_size: Sequence[int],
-    dilation: Sequence[int],
-    is_causal: Sequence[bool],
-    scale: float,
-    q_tiler: Sequence[int],
-    kv_tiler: Sequence[int],
-    out_shape: Any,
-):
-    return fna_flop_count(
-        q_shape=q_shape,
-        k_shape=k_shape,
-        v_shape=v_shape,
-        kernel_size=kernel_size,
-        dilation=dilation,
-        is_causal=is_causal,
-        is_heads_last=True,
-        return_macs=False,
-    )
-
-
-@register_flop_formula(torch.ops.natten.na3d_forward_op)
-def na3d_flop_count(
-    q_shape: Size,
-    k_shape: Size,
-    v_shape: Size,
-    bias: Optional[Tensor],
-    kernel_size: Sequence[int],
-    dilation: Sequence[int],
-    is_causal: Sequence[bool],
-    scale: float,
-    q_tiler: Sequence[int],
-    kv_tiler: Sequence[int],
-    out_shape: Any,
-):
-    return fna_flop_count(
-        q_shape=q_shape,
-        k_shape=k_shape,
-        v_shape=v_shape,
-        kernel_size=kernel_size,
-        dilation=dilation,
-        is_causal=is_causal,
-        is_heads_last=True,
-        return_macs=False,
-    )
-
-
-custom_mapping: dict[OpOverloadPacket, FlopCountFn] = {
-    torch.ops.natten.na1d_forward_op: na1d_flop_count,
-    torch.ops.natten.na2d_forward_op: na2d_flop_count,
-    torch.ops.natten.na3d_forward_op: na3d_flop_count,
-}
-
-
-#################################################################################################
-######################################## User-facing APIs #######################################
-#################################################################################################
-
-
-def na1d(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    kernel_size: Dimension1DTypeOrDed,
-    dilation: Dimension1DTypeOrDed = 1,
-    is_causal: Optional[CausalArg1DTypeOrDed] = False,
-    rpb: Optional[Tensor] = None,
-    scale: Optional[float] = None,
-    additional_keys: Optional[Tensor] = None,
-    additional_values: Optional[Tensor] = None,
-    xformers_kwargs: Optional[Dict] = None,
-) -> Tensor:
-    if query.is_nested or key.is_nested or value.is_nested:
-        raise NotImplementedError(
-            "Fused neighborhood attention does not support nested tensors yet."
+    try:
+        from natten import libnatten  # type: ignore
+    except ImportError:
+        raise ImportError(
+            "Failed to import libnatten. "
+            "This could be due to an invalid/incomplete install. "
+            "Please make sure you built NATTEN correctly, or refer to "
+            "https://shi-labs.com/natten for more information."
         )
 
-    kernel_size_, dilation_, is_causal_ = check_all_args(
-        1, kernel_size, dilation, is_causal
-    )
-    # TODO: autotuner and torch compile aren't supported together
-    tiling_config_forward = get_default_tiling_config_for_fna_forward(
-        1, input_tensor=query, dilation=dilation_
-    )
+    #################################################################################################
+    ##################################### Register forward ops. #####################################
+    #################################################################################################
 
-    scale = scale or query.shape[-1] ** -0.5
-
-    output, lse = torch.ops.natten.na1d_forward_op(
-        query,
-        key,
-        value,
-        rpb,
-        kernel_size_,
-        dilation_,
-        is_causal_,
-        scale,
-        *tiling_config_forward,
+    @torch.library.custom_op(
+        "natten::na1d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
     )
+    def na1d_torch_library_op(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        kernel_size, dilation, is_causal = check_all_args(
+            1, kernel_size_, dilation_, is_causal_
+        )
 
-    if additional_keys is not None and additional_values is not None:
-        if additional_keys is None or additional_values is None:
-            raise ValueError(
-                "Both `additional_keys` and `additional_values` must be "
-                "either Tensors or NoneTypes."
+        assert isinstance(
+            scale, float
+        ), f"Expected float attention scale, got {type(scale)}."
+
+        (q_tiler, kv_tiler) = check_tiling_config(1, (q_tiler_, kv_tiler_))
+
+        if any(is_causal) and bias is not None:
+            raise NotImplementedError(
+                "Positional biases for causal neighborhood attention is not yet implemented."
             )
 
-        additional_output, additional_lse = additional_sdpa(
+        # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+        # and instead indicate they require contiguous operands.
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
+        if bias is not None:
+            bias = bias.to(query.dtype).contiguous()
+        output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
+        )
+
+        libnatten.na1d_forward(
+            output,
             query,
-            additional_keys,
-            additional_values,
-            scale=scale,
-            attn_kwargs=xformers_kwargs,
+            key,
+            value,
+            bias,
+            logsumexp,
+            kernel_size,
+            dilation,
+            is_causal,
+            scale,
+            q_tiler,
+            kv_tiler,
         )
 
-        return merge_attentions(output, additional_output, lse, additional_lse)
+        return output, logsumexp
 
-    return output
-
-
-def na2d(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    kernel_size: Dimension2DTypeOrDed,
-    dilation: Dimension2DTypeOrDed = 1,
-    is_causal: Optional[CausalArg2DTypeOrDed] = False,
-    rpb: Optional[Tensor] = None,
-    scale: Optional[float] = None,
-    additional_keys: Optional[Tensor] = None,
-    additional_values: Optional[Tensor] = None,
-    xformers_kwargs: Optional[Dict] = None,
-) -> Tensor:
-    if query.is_nested or key.is_nested or value.is_nested:
-        raise NotImplementedError(
-            "Fused neighborhood attention does not support nested tensors yet."
+    @torch.library.custom_op(
+        "natten::na2d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
+    )
+    def na2d_torch_library_op(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        kernel_size, dilation, is_causal = check_all_args(
+            2, kernel_size_, dilation_, is_causal_
         )
 
-    kernel_size_, dilation_, is_causal_ = check_all_args(
-        2, kernel_size, dilation, is_causal
-    )
-    # TODO: autotuner and torch compile aren't supported together
-    tiling_config_forward = get_default_tiling_config_for_fna_forward(
-        2, input_tensor=query, dilation=dilation_
-    )
+        assert isinstance(
+            scale, float
+        ), f"Expected float attention scale, got {type(scale)}."
 
-    scale = scale or query.shape[-1] ** -0.5
+        (q_tiler, kv_tiler) = check_tiling_config(2, (q_tiler_, kv_tiler_))
 
-    output, lse = torch.ops.natten.na2d_forward_op(
-        query,
-        key,
-        value,
-        rpb,
-        kernel_size_,
-        dilation_,
-        is_causal_,
-        scale,
-        *tiling_config_forward,
-    )
-
-    if additional_keys is not None and additional_values is not None:
-        if additional_keys is None or additional_values is None:
-            raise ValueError(
-                "Both `additional_keys` and `additional_values` must be "
-                "either Tensors or NoneTypes."
+        if any(is_causal) and bias is not None:
+            raise NotImplementedError(
+                "Positional biases for causal neighborhood attention is not yet implemented."
             )
 
-        additional_output, additional_lse = additional_sdpa(
+        # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+        # and instead indicate they require contiguous operands.
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
+        if bias is not None:
+            bias = bias.to(query.dtype).contiguous()
+        output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
+        )
+
+        libnatten.na2d_forward(
+            output,
             query,
-            additional_keys,
-            additional_values,
-            scale=scale,
-            attn_kwargs=xformers_kwargs,
+            key,
+            value,
+            bias,
+            logsumexp,
+            kernel_size,
+            dilation,
+            is_causal,
+            scale,
+            q_tiler,
+            kv_tiler,
         )
 
-        return merge_attentions(output, additional_output, lse, additional_lse)
+        return output, logsumexp
 
-    return output
-
-
-def na3d(
-    query: Tensor,
-    key: Tensor,
-    value: Tensor,
-    kernel_size: Dimension3DTypeOrDed,
-    dilation: Dimension3DTypeOrDed = 1,
-    is_causal: Optional[CausalArg3DTypeOrDed] = False,
-    rpb: Optional[Tensor] = None,
-    scale: Optional[float] = None,
-    additional_keys: Optional[Tensor] = None,
-    additional_values: Optional[Tensor] = None,
-    xformers_kwargs: Optional[Dict] = None,
-) -> Tensor:
-    if query.is_nested or key.is_nested or value.is_nested:
-        raise NotImplementedError(
-            "Fused neighborhood attention does not support nested tensors yet."
+    @torch.library.custom_op(
+        "natten::na3d_forward_op", mutates_args=(), device_types=("cpu", "cuda")
+    )
+    def na3d_torch_library_op(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        kernel_size, dilation, is_causal = check_all_args(
+            3, kernel_size_, dilation_, is_causal_
         )
 
-    kernel_size_, dilation_, is_causal_ = check_all_args(
-        3, kernel_size, dilation, is_causal
-    )
-    # TODO: autotuner and torch compile aren't supported together
-    tiling_config_forward = get_default_tiling_config_for_fna_forward(
-        3, input_tensor=query, dilation=dilation_
-    )
+        assert isinstance(
+            scale, float
+        ), f"Expected float attention scale, got {type(scale)}."
 
-    scale = scale or query.shape[-1] ** -0.5
+        (q_tiler, kv_tiler) = check_tiling_config(3, (q_tiler_, kv_tiler_))
 
-    output, lse = torch.ops.natten.na3d_forward_op(
-        query,
-        key,
-        value,
-        rpb,
-        kernel_size_,
-        dilation_,
-        is_causal_,
-        scale,
-        *tiling_config_forward,
-    )
-
-    if additional_keys is not None and additional_values is not None:
-        if additional_keys is None or additional_values is None:
-            raise ValueError(
-                "Both `additional_keys` and `additional_values` must be "
-                "either Tensors or NoneTypes."
+        if any(is_causal) and bias is not None:
+            raise NotImplementedError(
+                "Positional biases for causal neighborhood attention is not yet implemented."
             )
 
-        additional_output, additional_lse = additional_sdpa(
-            query,
-            additional_keys,
-            additional_values,
-            scale=scale,
-            attn_kwargs=xformers_kwargs,
+        # NOTE: this is what needs a PyTorch fix; ops should not have to call .contiguous()
+        # and instead indicate they require contiguous operands.
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
+        if bias is not None:
+            bias = bias.to(query.dtype).contiguous()
+        output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
         )
 
-        return merge_attentions(output, additional_output, lse, additional_lse)
+        libnatten.na3d_forward(
+            output,
+            query,
+            key,
+            value,
+            bias,
+            logsumexp,
+            kernel_size,
+            dilation,
+            is_causal,
+            scale,
+            q_tiler,
+            kv_tiler,
+        )
 
-    return output
+        return output, logsumexp
+
+    #################################################################################################
+    ################## Register "fake" ops for forward op, since it's not inplace. ##################
+    #################################################################################################
+
+    @na1d_torch_library_op.register_fake
+    def na1d_op_fake(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        output = torch.empty_like(value)
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
+        )
+        return output, logsumexp
+
+    @na2d_torch_library_op.register_fake
+    def na2d_op_fake(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        output = torch.empty_like(value)
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
+        )
+        return output, logsumexp
+
+    @na3d_torch_library_op.register_fake
+    def na3d_op_fake(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        bias: Optional[Tensor],
+        kernel_size_: Sequence[int],
+        dilation_: Sequence[int],
+        is_causal_: Sequence[bool],
+        scale: float,
+        q_tiler_: Sequence[int],
+        kv_tiler_: Sequence[int],
+    ) -> Tuple[Tensor, Tensor]:
+        output = torch.empty_like(value)
+        # TODO: logsumexp should be conditional
+        logsumexp = torch.empty(
+            query.shape[:-1], dtype=torch.float32, device=query.device
+        )
+        return output, logsumexp
+
+    #################################################################################################
+    ########################################### FLOP Counts #########################################
+    #################################################################################################
+
+    class FlopCountFn(Protocol):
+        @staticmethod
+        def __call__(*args, **kwargs) -> int: ...
+
+    @register_flop_formula(torch.ops.natten.na1d_forward_op)
+    def na1d_flop_count(
+        q_shape: Size,
+        k_shape: Size,
+        v_shape: Size,
+        bias: Optional[Tensor],
+        kernel_size: Sequence[int],
+        dilation: Sequence[int],
+        is_causal: Sequence[bool],
+        scale: float,
+        q_tiler: Sequence[int],
+        kv_tiler: Sequence[int],
+        out_shape: Any,
+    ):
+        return fna_flop_count(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=False,
+        )
+
+    @register_flop_formula(torch.ops.natten.na2d_forward_op)
+    def na2d_flop_count(
+        q_shape: Size,
+        k_shape: Size,
+        v_shape: Size,
+        bias: Optional[Tensor],
+        kernel_size: Sequence[int],
+        dilation: Sequence[int],
+        is_causal: Sequence[bool],
+        scale: float,
+        q_tiler: Sequence[int],
+        kv_tiler: Sequence[int],
+        out_shape: Any,
+    ):
+        return fna_flop_count(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=False,
+        )
+
+    @register_flop_formula(torch.ops.natten.na3d_forward_op)
+    def na3d_flop_count(
+        q_shape: Size,
+        k_shape: Size,
+        v_shape: Size,
+        bias: Optional[Tensor],
+        kernel_size: Sequence[int],
+        dilation: Sequence[int],
+        is_causal: Sequence[bool],
+        scale: float,
+        q_tiler: Sequence[int],
+        kv_tiler: Sequence[int],
+        out_shape: Any,
+    ):
+        return fna_flop_count(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=False,
+        )
+
+    custom_mapping: dict[OpOverloadPacket, FlopCountFn] = {
+        torch.ops.natten.na1d_forward_op: na1d_flop_count,
+        torch.ops.natten.na2d_forward_op: na2d_flop_count,
+        torch.ops.natten.na3d_forward_op: na3d_flop_count,
+    }
+
+    #################################################################################################
+    ######################################## User-facing APIs #######################################
+    #################################################################################################
+
+    def na1d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension1DTypeOrDed,
+        dilation: Dimension1DTypeOrDed = 1,
+        is_causal: Optional[CausalArg1DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
+        if query.is_nested or key.is_nested or value.is_nested:
+            raise NotImplementedError(
+                "Fused neighborhood attention does not support nested tensors yet."
+            )
+
+        kernel_size_, dilation_, is_causal_ = check_all_args(
+            1, kernel_size, dilation, is_causal
+        )
+        # TODO: autotuner and torch compile aren't supported together
+        tiling_config_forward = get_default_tiling_config_for_fna_forward(
+            1, input_tensor=query, dilation=dilation_
+        )
+
+        scale = scale or query.shape[-1] ** -0.5
+
+        output, lse = torch.ops.natten.na1d_forward_op(
+            query,
+            key,
+            value,
+            rpb,
+            kernel_size_,
+            dilation_,
+            is_causal_,
+            scale,
+            *tiling_config_forward,
+        )
+
+        if additional_keys is not None and additional_values is not None:
+            if additional_keys is None or additional_values is None:
+                raise ValueError(
+                    "Both `additional_keys` and `additional_values` must be "
+                    "either Tensors or NoneTypes."
+                )
+
+            additional_output, additional_lse = additional_sdpa(
+                query,
+                additional_keys,
+                additional_values,
+                scale=scale,
+                attn_kwargs=xformers_kwargs,
+            )
+
+            return merge_attentions(output, additional_output, lse, additional_lse)
+
+        return output
+
+    def na2d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension2DTypeOrDed,
+        dilation: Dimension2DTypeOrDed = 1,
+        is_causal: Optional[CausalArg2DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
+        if query.is_nested or key.is_nested or value.is_nested:
+            raise NotImplementedError(
+                "Fused neighborhood attention does not support nested tensors yet."
+            )
+
+        kernel_size_, dilation_, is_causal_ = check_all_args(
+            2, kernel_size, dilation, is_causal
+        )
+        # TODO: autotuner and torch compile aren't supported together
+        tiling_config_forward = get_default_tiling_config_for_fna_forward(
+            2, input_tensor=query, dilation=dilation_
+        )
+
+        scale = scale or query.shape[-1] ** -0.5
+
+        output, lse = torch.ops.natten.na2d_forward_op(
+            query,
+            key,
+            value,
+            rpb,
+            kernel_size_,
+            dilation_,
+            is_causal_,
+            scale,
+            *tiling_config_forward,
+        )
+
+        if additional_keys is not None and additional_values is not None:
+            if additional_keys is None or additional_values is None:
+                raise ValueError(
+                    "Both `additional_keys` and `additional_values` must be "
+                    "either Tensors or NoneTypes."
+                )
+
+            additional_output, additional_lse = additional_sdpa(
+                query,
+                additional_keys,
+                additional_values,
+                scale=scale,
+                attn_kwargs=xformers_kwargs,
+            )
+
+            return merge_attentions(output, additional_output, lse, additional_lse)
+
+        return output
+
+    def na3d(
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        kernel_size: Dimension3DTypeOrDed,
+        dilation: Dimension3DTypeOrDed = 1,
+        is_causal: Optional[CausalArg3DTypeOrDed] = False,
+        rpb: Optional[Tensor] = None,
+        scale: Optional[float] = None,
+        additional_keys: Optional[Tensor] = None,
+        additional_values: Optional[Tensor] = None,
+        xformers_kwargs: Optional[Dict] = None,
+    ) -> Tensor:
+        if query.is_nested or key.is_nested or value.is_nested:
+            raise NotImplementedError(
+                "Fused neighborhood attention does not support nested tensors yet."
+            )
+
+        kernel_size_, dilation_, is_causal_ = check_all_args(
+            3, kernel_size, dilation, is_causal
+        )
+        # TODO: autotuner and torch compile aren't supported together
+        tiling_config_forward = get_default_tiling_config_for_fna_forward(
+            3, input_tensor=query, dilation=dilation_
+        )
+
+        scale = scale or query.shape[-1] ** -0.5
+
+        output, lse = torch.ops.natten.na3d_forward_op(
+            query,
+            key,
+            value,
+            rpb,
+            kernel_size_,
+            dilation_,
+            is_causal_,
+            scale,
+            *tiling_config_forward,
+        )
+
+        if additional_keys is not None and additional_values is not None:
+            if additional_keys is None or additional_values is None:
+                raise ValueError(
+                    "Both `additional_keys` and `additional_values` must be "
+                    "either Tensors or NoneTypes."
+                )
+
+            additional_output, additional_lse = additional_sdpa(
+                query,
+                additional_keys,
+                additional_values,
+                scale=scale,
+                attn_kwargs=xformers_kwargs,
+            )
+
+            return merge_attentions(output, additional_output, lse, additional_lse)
+
+        return output

--- a/src/natten/flops.py
+++ b/src/natten/flops.py
@@ -79,7 +79,7 @@ def _na_av_flops(
 
 # "Heads last" layout -- primarily used in fused impls.
 def _get_parameters_from_inputs_BLHD(
-    input_shape: torch.Size | Sequence[int] | List[int],
+    input_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -114,7 +114,7 @@ def _get_parameters_from_inputs_BLHD(
 
 # "Heads first" layout -- primarily used in BMM impls.
 def _get_parameters_from_inputs_BHLD(
-    input_shape: torch.Size | Sequence[int] | List[int],
+    input_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -148,7 +148,7 @@ def _get_parameters_from_inputs_BHLD(
 
 
 def _count_na_flops_generic(
-    input_shape: torch.Size | Sequence[int] | List[int],
+    input_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -192,9 +192,9 @@ def _count_na_flops_generic(
 
 
 def fna_flop_count(
-    q_shape: torch.Size | Sequence[int] | List[int],
-    k_shape: torch.Size | Sequence[int] | List[int],
-    v_shape: torch.Size | Sequence[int] | List[int],
+    q_shape: torch.Size | Sequence[int],
+    k_shape: torch.Size | Sequence[int],
+    v_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -219,8 +219,8 @@ def fna_flop_count(
 
 
 def na_qk_flop_count(
-    q_shape: torch.Size | Sequence[int] | List[int],
-    k_shape: torch.Size | Sequence[int] | List[int],
+    q_shape: torch.Size | Sequence[int],
+    k_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],
@@ -245,8 +245,8 @@ def na_qk_flop_count(
 
 
 def na_av_flop_count(
-    a_shape: torch.Size | Sequence[int] | List[int],
-    v_shape: torch.Size | Sequence[int] | List[int],
+    a_shape: torch.Size | Sequence[int],
+    v_shape: torch.Size | Sequence[int],
     kernel_size: Sequence[int],
     dilation: Sequence[int],
     is_causal: Sequence[bool],

--- a/src/natten/flops.py
+++ b/src/natten/flops.py
@@ -135,7 +135,10 @@ def fna_generic_flops(inputs: List[Any], outputs: List[Any]) -> Number:
 
     flops = batch_size * heads * spatial_extent_int * dim * kernel_size_int  # QK
 
-    flops += batch_size * heads * spatial_extent_int * kernel_size_int  # softmax
+    # NOTE: PyTorch doesn't count softmax flops in SDPA;
+    # Reference:
+    # https://github.com/pytorch/pytorch/blob/7ced49d2ccf219ec896810e6d988709c3a3a2d9a/torch/utils/flop_counter.py#L241-L256
+    # flops += batch_size * heads * spatial_extent_int * kernel_size_int  # softmax
     flops += batch_size * heads * spatial_extent_int * dim * kernel_size_int  # AV
 
     if has_bias:
@@ -170,7 +173,6 @@ def qk_1d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
     has_rpb = len(inputs) == 3
 
     flops = batch_size * heads * length * dim * kernel_size
-    # TODO: why is the sum of exps reduction not included in softmax's flops?
     flops += batch_size * heads * length * kernel_size
     if has_rpb:
         flops += batch_size * heads * length * kernel_size
@@ -231,7 +233,6 @@ def qk_2d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
     has_rpb = len(inputs) == 3
 
     flops = batch_size * heads * height * width * dim * kernel_size_sq
-    # TODO: why is the sum of exps reduction not included in softmax's flops?
     flops += batch_size * heads * height * width * kernel_size_sq
     if has_rpb:
         flops += batch_size * heads * height * width * kernel_size_sq
@@ -292,7 +293,6 @@ def qk_3d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
     has_rpb = len(inputs) == 3
 
     flops = batch_size * heads * depth * height * width * dim * kernel_size_cu
-    # TODO: why is the sum of exps reduction not included in softmax's flops?
     flops += batch_size * heads * depth * height * width * kernel_size_cu
     if has_rpb:
         flops += batch_size * heads * depth * height * width * kernel_size_cu

--- a/src/natten/flops.py
+++ b/src/natten/flops.py
@@ -20,338 +20,525 @@
 # SOFTWARE.
 #
 #################################################################################################
+
+#
+# NATTEN's FLOP/MAC utilities and helpers.
+#
+# NATTEN supports two FLOP counters: torch.utils.flop_counter, and fvcore.
+# NATTEN implements its own counters, and provides APIs for torch.utils.flop_counter
+# and fvcore.
+#
+# NOTE: fvcore computes MACs, not FLOPs. GEMM flops in fvcore are MNK not 2MNK.
+#
+
 import math
-from numbers import Number
-from typing import Any, List
+from typing import Any, List, Sequence, Tuple
 
-from fvcore.nn import FlopCountAnalysis  # type: ignore
-from fvcore.nn.jit_handles import get_shape  # type: ignore
+import torch
+
+from .utils import check_all_args, get_num_na_weights
 
 
-def fna_generic_flops(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for generic fused neighborhood attention.
-    """
-    assert (
-        len(inputs) >= 3
-    ), f"Expected at least 3 inputs (query, key, value), got {len(inputs)}"
-    has_bias = len(inputs) == 4 and inputs[-1] is not None
-    input_shapes = [get_shape(v) for v in inputs]
+def _bmm_flops(b: int, m: int, n: int, k: int) -> int:
+    return 2 * b * m * n * k
 
-    # Weird fvcore / jit bug
-    assert len(outputs) in [
-        1,
-        2,
-    ], f"Expected exactly 1 or 2 outputs (tuple), got {len(outputs)}"
-    if len(outputs) == 1:
-        outputs_ = outputs[0].uses()[0].user.outputs()
-        output_shapes = [get_shape(v) for v in outputs_]
-        assert (
-            len(output_shapes) == 2
-        ), f"Expected exactly 2 outputs (attention output, and LSE), got {len(output_shapes)}"
-    else:
-        assert (
-            len(outputs) == 2
-        ), f"Expected exactly 2 outputs (attention output, and LSE), got {len(outputs)}"
-        output_shapes = [get_shape(v) for v in outputs]
 
-    assert len(input_shapes[0]) in [
-        4,
-        5,
-        6,
-    ], f"Input tensors must be of rank 4, 5, or 6, got {len(input_shapes[0])}"
+def _bmm_macs(b: int, m: int, n: int, k: int) -> int:
+    return b * m * n * k
 
-    assert len(input_shapes[1]) == len(input_shapes[1]) == len(input_shapes[2]), (
-        f"All input tensors must be of the same rank, got {len(input_shapes[0])}, "
-        + f"{len(input_shapes[1])} and {len(input_shapes[2])}"
+
+def _na_qk_flops(
+    batch_size: int,
+    heads: int,
+    num_tokens: int,
+    dim: int,
+    num_attn_weights: int,
+    return_macs: bool = False,
+) -> int:
+    b = batch_size * heads
+    m = num_tokens
+    n = num_attn_weights
+    k = dim
+    return _bmm_macs(b, m, n, k) if return_macs else _bmm_flops(b, m, n, k)
+
+
+def _na_av_flops(
+    batch_size: int,
+    heads: int,
+    num_tokens: int,
+    dim: int,
+    num_attn_weights: int,
+    return_macs: bool = False,
+) -> int:
+    b = batch_size * heads
+    m = num_tokens
+    n = dim
+    k = num_attn_weights
+    return _bmm_macs(b, m, n, k) if return_macs else _bmm_flops(b, m, n, k)
+
+
+# "Heads last" layout -- primarily used in fused impls.
+def _get_parameters_from_inputs_BLHD(
+    input_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+) -> Tuple[int, int, int, int, int]:  # batch, heads, num_tokens, dim, num_attn_weights
+    assert len(input_shape) in [4, 5, 6], (
+        "Expected QKV shapes to be either 4D, 5D, or 6D (for 1D, 2D and 3D NA respectively), got "
+        + f"{input_shape}."
+    )
+    na_dim = len(input_shape) - 3
+
+    kernel_size_, dilation_, is_causal_ = check_all_args(
+        na_dim, kernel_size, dilation, is_causal
     )
 
-    assert len(output_shapes[0]) == len(
-        input_shapes[0]
-    ), f"Output tensor must match the rank of input tensors, got {len(output_shapes[0])} != {len(input_shapes[0])}"
-    assert len(output_shapes[1]) == len(
-        output_shapes[0][:-1]
-    ), f"Mismatch between output and LSE shape, got {len(output_shapes[0])} != {len(output_shapes[1])}"
-
-    assert input_shapes[0] == input_shapes[1] == input_shapes[2] == output_shapes[0], (
-        "Query, key, value, and output must match in shape, got q.shape="
-        + f"{input_shapes[0]}, k.shape={input_shapes[1]}, v.shape={input_shapes[1]}."
-    )
     batch_size, heads, dim = (
-        input_shapes[0][0],
-        input_shapes[0][-2],
-        input_shapes[0][-1],
+        input_shape[0],
+        input_shape[-2],
+        input_shape[-1],
     )
 
-    # NOTE: really hacky way to extract non-tensor args, but gets the job done.
-    # The jit trace only picks up tensor operands in inputs and outputs, but
-    # it's impossible to compute FLOPs without knowing kernel size.
-    assert hasattr(inputs[0], "uses") and callable(inputs[0].uses)
-    _uses = inputs[0].uses()
-    assert (
-        hasattr(_uses, "__len__")
-        and len(_uses) == 1
-        and hasattr(_uses[0], "user")
-        and hasattr(_uses[0].user, "scalar_args")
-        and callable(_uses[0].user.scalar_args)
-    )
-    scalar_args = _uses[0].user.scalar_args()
-    assert hasattr(scalar_args, "__len__") and len(scalar_args) in [
-        6,
-        7,
-    ], f"Expected 6 or 7 non-tensor args to the op, got {len(scalar_args)}. {scalar_args=}"
-
-    # Kick off rpb=None
-    if len(scalar_args) == 7:
-        assert scalar_args[0] is None
-        scalar_args = scalar_args[1:]
-
-    (
-        kernel_size,
-        dilation,
-        is_causal,
-        attn_scale,
-        tiling_config,
-        tiling_config_backward,
-    ) = scalar_args
-    # TODO: it's very easy to hit this assertion. We must make sure
-    # arguments like kernel size are checked before calling the autograd function,
-    # not inside it.
-    assert isinstance(
-        kernel_size, tuple
-    ), f"Expected kernel_size to be a tuple, got {type(kernel_size)=}."
-
-    assert len(kernel_size) + 3 == len(input_shapes[0]), (
-        "Tensor rank must be equal to len(kernel_size) + 3 = "
-        + f"{len(kernel_size) + 3}, got {len(input_shapes[0])}"
+    spatial_extent = input_shape[1 : na_dim + 1]
+    assert len(spatial_extent) == len(kernel_size_) == na_dim, (
+        f"Expected both spatial extent and kernel size to be {na_dim} tuples, got "
+        + f"{len(spatial_extent)=}, {len(kernel_size_)=}."
     )
 
-    spatial_extent = input_shapes[0][1 : len(kernel_size) + 1]
+    num_tokens = math.prod(spatial_extent)
+    num_attn_weights = get_num_na_weights(kernel_size_)
 
-    assert len(spatial_extent) == len(kernel_size)
-
-    spatial_extent_int = math.prod(spatial_extent)
-    kernel_size_int = math.prod(kernel_size)
-
-    flops = batch_size * heads * spatial_extent_int * dim * kernel_size_int  # QK
-
-    # NOTE: PyTorch doesn't count softmax flops in SDPA;
-    # Reference:
-    # https://github.com/pytorch/pytorch/blob/7ced49d2ccf219ec896810e6d988709c3a3a2d9a/torch/utils/flop_counter.py#L241-L256
-    # flops += batch_size * heads * spatial_extent_int * kernel_size_int  # softmax
-    flops += batch_size * heads * spatial_extent_int * dim * kernel_size_int  # AV
-
-    if has_bias:
-        flops += batch_size * heads * spatial_extent_int * kernel_size_int  # RPB
-    return flops
+    return (batch_size, heads, num_tokens, dim, num_attn_weights)
 
 
-def qk_1d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 1D QK operation.
-    """
-    assert (
-        len(inputs) >= 2
-    ), f"Expected at least 2 inputs (query, key), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (attn), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 4
-    ), f"Query must be a 4-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 4
-    ), f"Key must be a 4-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 4
-    ), f"Output must be a 4-dim tensor, got {len(output_shapes[0])}"
-    assert (
-        input_shapes[0] == input_shapes[1]
-    ), f"Query and Key shapes did not match! Q: {input_shapes[0]}, K: {input_shapes[1]}"
-    batch_size, heads, length, dim = input_shapes[0]
-    batch_size, heads, length, kernel_size = output_shapes[0]
-    has_rpb = len(inputs) == 3
-
-    flops = batch_size * heads * length * dim * kernel_size
-    flops += batch_size * heads * length * kernel_size
-    if has_rpb:
-        flops += batch_size * heads * length * kernel_size
-    return flops
-
-
-def av_1d_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 1D AV operation.
-    """
-    assert len(inputs) == 2, f"Expected 2 inputs (attn and value), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (out), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 4
-    ), f"Attn must be a 4-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 4
-    ), f"Value must be a 4-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 4
-    ), f"Output must be a 4-dim tensor, got {len(output_shapes[0])}"
-    assert output_shapes[0] == input_shapes[1], (
-        f"Out and Value shapes did not match! O: {output_shapes[0]}, V:"
-        f" {input_shapes[1]}"
+# "Heads first" layout -- primarily used in BMM impls.
+def _get_parameters_from_inputs_BHLD(
+    input_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+) -> Tuple[int, int, int, int, int]:  # batch, heads, num_tokens, dim, num_attn_weights
+    assert len(input_shape) in [4, 5, 6], (
+        "Expected QKV shapes to be either 4D, 5D, or 6D (for 1D, 2D and 3D NA respectively), got "
+        + f"{input_shape}."
     )
-    batch_size, heads, length, kernel_size = input_shapes[0]
-    batch_size, heads, length, dim = output_shapes[0]
-    flops = batch_size * heads * length * dim * kernel_size
-    return flops
+    na_dim = len(input_shape) - 3
 
-
-def qk_2d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 2D QK operation.
-    """
-    assert (
-        len(inputs) >= 2
-    ), f"Expected at least 2 inputs (query, key), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (attn), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 5
-    ), f"Query must be a 5-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 5
-    ), f"Key must be a 5-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 5
-    ), f"Output must be a 5-dim tensor, got {len(output_shapes[0])}"
-    assert (
-        input_shapes[0] == input_shapes[1]
-    ), f"Query and Key shapes did not match! Q: {input_shapes[0]}, K: {input_shapes[1]}"
-    batch_size, heads, height, width, dim = input_shapes[0]
-    batch_size, heads, height, width, kernel_size_sq = output_shapes[0]
-    has_rpb = len(inputs) == 3
-
-    flops = batch_size * heads * height * width * dim * kernel_size_sq
-    flops += batch_size * heads * height * width * kernel_size_sq
-    if has_rpb:
-        flops += batch_size * heads * height * width * kernel_size_sq
-    return flops
-
-
-def av_2d_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 2D AV operation.
-    """
-    assert len(inputs) == 2, f"Expected 2 inputs (attn and value), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (out), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 5
-    ), f"Attn must be a 5-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 5
-    ), f"Value must be a 5-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 5
-    ), f"Output must be a 5-dim tensor, got {len(output_shapes[0])}"
-    assert output_shapes[0] == input_shapes[1], (
-        f"Out and Value shapes did not match! O: {output_shapes[0]}, V:"
-        f" {input_shapes[1]}"
-    )
-    batch_size, heads, height, width, kernel_size_sq = input_shapes[0]
-    batch_size, heads, height, width, dim = output_shapes[0]
-    flops = batch_size * heads * height * width * dim * kernel_size_sq
-    return flops
-
-
-def qk_3d_rpb_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 3D QK operation.
-    """
-    assert (
-        len(inputs) >= 2
-    ), f"Expected at least 2 inputs (query, key), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (attn), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 6
-    ), f"Query must be a 6-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 6
-    ), f"Key must be a 6-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 6
-    ), f"Output must be a 6-dim tensor, got {len(output_shapes[0])}"
-    assert (
-        input_shapes[0] == input_shapes[1]
-    ), f"Query and Key shapes did not match! Q: {input_shapes[0]}, K: {input_shapes[1]}"
-    batch_size, heads, depth, height, width, dim = input_shapes[0]
-    batch_size, heads, depth, height, width, kernel_size_cu = output_shapes[0]
-    has_rpb = len(inputs) == 3
-
-    flops = batch_size * heads * depth * height * width * dim * kernel_size_cu
-    flops += batch_size * heads * depth * height * width * kernel_size_cu
-    if has_rpb:
-        flops += batch_size * heads * depth * height * width * kernel_size_cu
-    return flops
-
-
-def av_3d_flop(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Counts flops for the 3D AV operation.
-    """
-    assert len(inputs) == 2, f"Expected 2 inputs (attn and value), got {len(inputs)}"
-    assert len(outputs) == 1, f"Expected 1 output (out), got {len(outputs)}"
-    input_shapes = [get_shape(v) for v in inputs]
-    output_shapes = [get_shape(v) for v in outputs]
-    assert (
-        len(input_shapes[0]) == 6
-    ), f"Attn must be a 6-dim tensor, got {len(input_shapes[0])}"
-    assert (
-        len(input_shapes[1]) == 6
-    ), f"Value must be a 6-dim tensor, got {len(input_shapes[1])}"
-    assert (
-        len(output_shapes[0]) == 6
-    ), f"Output must be a 6-dim tensor, got {len(output_shapes[0])}"
-    assert output_shapes[0] == input_shapes[1], (
-        f"Out and Value shapes did not match! O: {output_shapes[0]}, V:"
-        f" {input_shapes[1]}"
-    )
-    batch_size, heads, depth, height, width, kernel_size_cu = input_shapes[0]
-    batch_size, heads, depth, height, width, dim = output_shapes[0]
-    flops = batch_size * heads * depth * height * width * dim * kernel_size_cu
-    return flops
-
-
-def add_natten_handle(flop_ctr):
-    return flop_ctr.set_op_handle(
-        **{
-            "prim::PythonOp.NATTEN1DQKRPBFunction": qk_1d_rpb_flop,
-            "prim::PythonOp.NATTEN1DAVFunction": av_1d_flop,
-            "prim::PythonOp.NATTEN2DQKRPBFunction": qk_2d_rpb_flop,
-            "prim::PythonOp.NATTEN2DAVFunction": av_2d_flop,
-            "prim::PythonOp.NATTEN3DQKRPBFunction": qk_3d_rpb_flop,
-            "prim::PythonOp.NATTEN3DAVFunction": av_3d_flop,
-            "prim::PythonOp.NeighborhoodAttention1DQKAutogradFunction": qk_1d_rpb_flop,
-            "prim::PythonOp.NeighborhoodAttention1DAVAutogradFunction": av_1d_flop,
-            "prim::PythonOp.NeighborhoodAttention2DQKAutogradFunction": qk_2d_rpb_flop,
-            "prim::PythonOp.NeighborhoodAttention2DAVAutogradFunction": av_2d_flop,
-            "prim::PythonOp.NeighborhoodAttention3DQKAutogradFunction": qk_3d_rpb_flop,
-            "prim::PythonOp.NeighborhoodAttention3DAVAutogradFunction": av_3d_flop,
-            # Fused ops
-            "prim::PythonOp.FusedNeighborhoodAttention1D": fna_generic_flops,
-            "prim::PythonOp.FusedNeighborhoodAttention2D": fna_generic_flops,
-            "prim::PythonOp.FusedNeighborhoodAttention3D": fna_generic_flops,
-        }
+    kernel_size_, dilation_, is_causal_ = check_all_args(
+        na_dim, kernel_size, dilation, is_causal
     )
 
+    batch_size, heads, dim = (
+        input_shape[0],
+        input_shape[1],
+        input_shape[-1],
+    )
 
-def get_flops(model, input, disable_warnings=False):
-    flop_ctr = FlopCountAnalysis(model, input)
-    flop_ctr = add_natten_handle(flop_ctr)
-    if disable_warnings:
-        flop_ctr = flop_ctr.unsupported_ops_warnings(False)
-    return flop_ctr.total()
+    spatial_extent = input_shape[2 : na_dim + 2]
+    assert len(spatial_extent) == len(kernel_size_) == na_dim, (
+        f"Expected both spatial extent and kernel size to be {na_dim} tuples, got "
+        + f"{len(spatial_extent)=}, {len(kernel_size_)=}."
+    )
+
+    num_tokens = math.prod(spatial_extent)
+    num_attn_weights = get_num_na_weights(kernel_size_)
+
+    return (batch_size, heads, num_tokens, dim, num_attn_weights)
+
+
+def _count_na_flops_generic(
+    input_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> Tuple[int, int]:
+    (batch_size, heads, num_tokens, dim, num_attn_weights) = (
+        _get_parameters_from_inputs_BLHD
+        if is_heads_last
+        else _get_parameters_from_inputs_BHLD
+    )(
+        input_shape=input_shape,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        is_causal=is_causal,
+    )
+
+    # TODO: causal masking does not affect FLOPs/MACs, when it should.
+    # But if we go down that rabbit hole, we should also consider counting FLOPs for
+    # non-TC operations, but separately, and report both in a reasonable manner.
+    # Non-TC ops and TC ops shouldn't be combined, because they are not expected to have
+    # at all similar implications. But that's a rant for a different day.
+    qk_flops = _na_qk_flops(
+        batch_size=batch_size,
+        heads=heads,
+        num_tokens=num_tokens,
+        dim=dim,
+        num_attn_weights=num_attn_weights,
+        return_macs=return_macs,
+    )
+    av_flops = _na_av_flops(
+        batch_size=batch_size,
+        heads=heads,
+        num_tokens=num_tokens,
+        dim=dim,
+        num_attn_weights=num_attn_weights,
+        return_macs=return_macs,
+    )
+
+    return qk_flops, av_flops
+
+
+def fna_flop_count(
+    q_shape: torch.Size | Sequence[int] | List[int],
+    k_shape: torch.Size | Sequence[int] | List[int],
+    v_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> int:
+    assert (
+        q_shape == k_shape == v_shape
+    ), f"Expected identical QKV shapes, got {q_shape=}, {k_shape=}, {v_shape=}."
+
+    qk_flops, av_flops = _count_na_flops_generic(
+        input_shape=q_shape,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        is_causal=is_causal,
+        is_heads_last=is_heads_last,
+        return_macs=return_macs,
+    )
+
+    # NOTE: attention bias and softmax are ignored.
+    return qk_flops + av_flops
+
+
+def na_qk_flop_count(
+    q_shape: torch.Size | Sequence[int] | List[int],
+    k_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> int:
+    assert (
+        q_shape == k_shape
+    ), f"Expected identical Q and K shapes, got {q_shape=}, {k_shape=}."
+
+    qk_flops, _ = _count_na_flops_generic(
+        input_shape=q_shape,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        is_causal=is_causal,
+        is_heads_last=is_heads_last,
+        return_macs=return_macs,
+    )
+
+    # NOTE: attention bias and softmax are ignored.
+    return qk_flops
+
+
+def na_av_flop_count(
+    a_shape: torch.Size | Sequence[int] | List[int],
+    v_shape: torch.Size | Sequence[int] | List[int],
+    kernel_size: Sequence[int],
+    dilation: Sequence[int],
+    is_causal: Sequence[bool],
+    is_heads_last: bool,
+    return_macs: bool = False,
+) -> int:
+
+    _, av_flops = _count_na_flops_generic(
+        input_shape=v_shape,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        is_causal=is_causal,
+        is_heads_last=is_heads_last,
+        return_macs=return_macs,
+    )
+    return av_flops
+
+
+#################################################################################################
+########################################## FVCore addons ########################################
+#################################################################################################
+
+
+try:
+    from fvcore.nn import FlopCountAnalysis  # type: ignore
+    from fvcore.nn.jit_handles import get_shape  # type: ignore
+
+    has_fvcore = True
+
+except ImportError:
+    has_fvcore = False
+
+
+if has_fvcore:
+
+    def _fvcore_fna_mac_count(inputs: List[Any], outputs: List[Any]) -> int:
+        assert (
+            len(inputs) >= 3
+        ), f"Expected at least 3 inputs (query, key, value), got {len(inputs)}"
+        input_shapes = [get_shape(v) for v in inputs]
+
+        # Weird fvcore / jit bug
+        assert len(outputs) in [
+            1,
+            2,
+        ], f"Expected exactly 1 or 2 outputs (tuple), got {len(outputs)}"
+        if len(outputs) == 1:
+            outputs_ = outputs[0].uses()[0].user.outputs()
+            output_shapes = [get_shape(v) for v in outputs_]
+            assert (
+                len(output_shapes) == 2
+            ), f"Expected exactly 2 outputs (attention output, and LSE), got {len(output_shapes)}"
+        else:
+            assert (
+                len(outputs) == 2
+            ), f"Expected exactly 2 outputs (attention output, and LSE), got {len(outputs)}"
+            output_shapes = [get_shape(v) for v in outputs]
+
+        assert len(input_shapes[0]) in [
+            4,
+            5,
+            6,
+        ], f"Input tensors must be of rank 4, 5, or 6, got {len(input_shapes[0])}"
+
+        assert len(input_shapes[1]) == len(input_shapes[1]) == len(input_shapes[2]), (
+            f"All input tensors must be of the same rank, got {len(input_shapes[0])}, "
+            + f"{len(input_shapes[1])} and {len(input_shapes[2])}"
+        )
+
+        assert len(output_shapes[0]) == len(
+            input_shapes[0]
+        ), f"Output tensor must match the rank of input tensors, got {len(output_shapes[0])} != {len(input_shapes[0])}"
+        assert len(output_shapes[1]) == len(
+            output_shapes[0][:-1]
+        ), f"Mismatch between output and LSE shape, got {len(output_shapes[0])} != {len(output_shapes[1])}"
+
+        assert (
+            input_shapes[0] == input_shapes[1] == input_shapes[2] == output_shapes[0]
+        ), (
+            "Query, key, value, and output must match in shape, got q.shape="
+            + f"{input_shapes[0]}, k.shape={input_shapes[1]}, v.shape={input_shapes[1]}."
+        )
+
+        # NOTE: really hacky way to extract non-tensor args, but gets the job done.
+        # The jit trace only picks up tensor operands in inputs and outputs, but
+        # it's impossible to compute FLOPs without knowing kernel size.
+        assert hasattr(inputs[0], "uses") and callable(inputs[0].uses)
+        _uses = inputs[0].uses()
+        assert (
+            hasattr(_uses, "__len__")
+            and len(_uses) == 1
+            and hasattr(_uses[0], "user")
+            and hasattr(_uses[0].user, "scalar_args")
+            and callable(_uses[0].user.scalar_args)
+        )
+        scalar_args = _uses[0].user.scalar_args()
+        assert hasattr(scalar_args, "__len__") and len(scalar_args) in [
+            6,
+            7,
+        ], f"Expected 6 or 7 non-tensor args to the op, got {len(scalar_args)}. {scalar_args=}"
+
+        # Kick off rpb=None
+        if len(scalar_args) == 7:
+            assert scalar_args[0] is None
+            scalar_args = scalar_args[1:]
+
+        (
+            kernel_size,
+            dilation,
+            is_causal,
+            attn_scale,
+            tiling_config,
+            tiling_config_backward,
+        ) = scalar_args
+        # TODO: it's very easy to hit this assertion. We must make sure
+        # arguments like kernel size are checked before calling the autograd function,
+        # not inside it.
+        assert isinstance(
+            kernel_size, tuple
+        ), f"Expected kernel_size to be a tuple, got {type(kernel_size)=}."
+
+        assert len(kernel_size) + 3 == len(input_shapes[0]), (
+            "Tensor rank must be equal to len(kernel_size) + 3 = "
+            + f"{len(kernel_size) + 3}, got {len(input_shapes[0])}"
+        )
+
+        q_shape = input_shapes[0]
+        k_shape = input_shapes[1]
+        v_shape = input_shapes[2]
+
+        return fna_flop_count(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            v_shape=v_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=True,  # FVCore reports MACs, not FLOPs.
+        )
+
+    def _fvcore_na_qk_mac_count(inputs: List[Any], outputs: List[Any]) -> int:
+        assert (
+            len(inputs) >= 2
+        ), f"Expected at least 2 inputs (query, key), got {len(inputs)}"
+        assert len(outputs) == 1, f"Expected 1 output (attn), got {len(outputs)}"
+        input_shapes = [get_shape(v) for v in inputs]
+
+        # NOTE: really hacky way to extract non-tensor args, but gets the job done.
+        # The jit trace only picks up tensor operands in inputs and outputs, but
+        # it's impossible to compute FLOPs without knowing kernel size.
+        assert hasattr(inputs[0], "uses") and callable(inputs[0].uses)
+        _uses = inputs[0].uses()
+        assert (
+            hasattr(_uses, "__len__")
+            and len(_uses) == 1
+            and hasattr(_uses[0], "user")
+            and hasattr(_uses[0].user, "scalar_args")
+            and callable(_uses[0].user.scalar_args)
+        )
+        scalar_args = _uses[0].user.scalar_args()
+        assert hasattr(scalar_args, "__len__") and len(scalar_args) in [
+            3,
+            4,
+            5,
+        ], f"Expected 3, 4 or 5 non-tensor args to the op, got {len(scalar_args)}. {scalar_args=}"
+
+        # Kick off optional bias, additional keys
+        if len(scalar_args) > 3:
+            num_nones = len(scalar_args) - 3
+            assert num_nones in [1, 2]
+            for i in range(num_nones):
+                assert scalar_args[i] is None
+            scalar_args = scalar_args[num_nones:]
+
+        (
+            kernel_size,
+            dilation,
+            is_causal,
+        ) = scalar_args
+        # TODO: it's very easy to hit this assertion. We must make sure
+        # arguments like kernel size are checked before calling the autograd function,
+        # not inside it.
+        assert isinstance(
+            kernel_size, tuple
+        ), f"Expected kernel_size to be a tuple, got {type(kernel_size)=}."
+
+        assert len(kernel_size) + 3 == len(input_shapes[0]), (
+            "Tensor rank must be equal to len(kernel_size) + 3 = "
+            + f"{len(kernel_size) + 3}, got {len(input_shapes[0])}"
+        )
+
+        q_shape = input_shapes[0]
+        k_shape = input_shapes[1]
+
+        return na_qk_flop_count(
+            q_shape=q_shape,
+            k_shape=k_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=True,  # FVCore reports MACs, not FLOPs.
+        )
+
+    def _fvcore_na_av_mac_count(inputs: List[Any], outputs: List[Any]) -> int:
+        assert (
+            len(inputs) == 2
+        ), f"Expected 2 inputs (attn and value), got {len(inputs)}"
+        assert len(outputs) == 1, f"Expected 1 output (out), got {len(outputs)}"
+        input_shapes = [get_shape(v) for v in inputs]
+
+        # NOTE: really hacky way to extract non-tensor args, but gets the job done.
+        # The jit trace only picks up tensor operands in inputs and outputs, but
+        # it's impossible to compute FLOPs without knowing kernel size.
+        assert hasattr(inputs[0], "uses") and callable(inputs[0].uses)
+        _uses = inputs[0].uses()
+        assert (
+            hasattr(_uses, "__len__")
+            and len(_uses) == 1
+            and hasattr(_uses[0], "user")
+            and hasattr(_uses[0].user, "scalar_args")
+            and callable(_uses[0].user.scalar_args)
+        )
+        scalar_args = _uses[0].user.scalar_args()
+        assert hasattr(scalar_args, "__len__") and len(scalar_args) in [
+            3,
+            4,
+        ], f"Expected 3 or 4 non-tensor args to the op, got {len(scalar_args)}. {scalar_args=}"
+
+        # Kick off optional additional values
+        if len(scalar_args) == 4:
+            assert scalar_args[0] is None
+            scalar_args = scalar_args[1:]
+
+        (
+            kernel_size,
+            dilation,
+            is_causal,
+        ) = scalar_args
+        # TODO: it's very easy to hit this assertion. We must make sure
+        # arguments like kernel size are checked before calling the autograd function,
+        # not inside it.
+        assert isinstance(
+            kernel_size, tuple
+        ), f"Expected kernel_size to be a tuple, got {type(kernel_size)=}."
+
+        assert len(kernel_size) + 3 == len(input_shapes[0]), (
+            "Tensor rank must be equal to len(kernel_size) + 3 = "
+            + f"{len(kernel_size) + 3}, got {len(input_shapes[0])}"
+        )
+
+        a_shape = input_shapes[0]
+        v_shape = input_shapes[1]
+
+        return na_av_flop_count(
+            a_shape=a_shape,
+            v_shape=v_shape,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            is_heads_last=True,
+            return_macs=True,  # FVCore reports MACs, not FLOPs.
+        )
+
+    def add_natten_handle(flop_ctr):
+        return flop_ctr.set_op_handle(
+            **{
+                # Legacy
+                "prim::PythonOp.NATTEN1DQKRPBFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NATTEN1DAVFunction": _fvcore_na_av_mac_count,
+                "prim::PythonOp.NATTEN2DQKRPBFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NATTEN2DAVFunction": _fvcore_na_av_mac_count,
+                "prim::PythonOp.NATTEN3DQKRPBFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NATTEN3DAVFunction": _fvcore_na_av_mac_count,
+                # Unfused
+                "prim::PythonOp.NeighborhoodAttention1DQKAutogradFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NeighborhoodAttention1DAVAutogradFunction": _fvcore_na_av_mac_count,
+                "prim::PythonOp.NeighborhoodAttention2DQKAutogradFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NeighborhoodAttention2DAVAutogradFunction": _fvcore_na_av_mac_count,
+                "prim::PythonOp.NeighborhoodAttention3DQKAutogradFunction": _fvcore_na_qk_mac_count,
+                "prim::PythonOp.NeighborhoodAttention3DAVAutogradFunction": _fvcore_na_av_mac_count,
+                # Fused ops
+                "prim::PythonOp.FusedNeighborhoodAttention1D": _fvcore_fna_mac_count,
+                "prim::PythonOp.FusedNeighborhoodAttention2D": _fvcore_fna_mac_count,
+                "prim::PythonOp.FusedNeighborhoodAttention3D": _fvcore_fna_mac_count,
+            }
+        )
+
+    def get_flops(model, input, disable_warnings=False):
+        flop_ctr = FlopCountAnalysis(model, input)
+        flop_ctr = add_natten_handle(flop_ctr)
+        if disable_warnings:
+            flop_ctr = flop_ctr.unsupported_ops_warnings(False)
+        return flop_ctr.total()

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -1175,6 +1175,8 @@ class FusedNeighborhoodAttention1D(Function):
         if bias is not None:
             bias = bias.to(query.dtype).contiguous()
         output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
         logsumexp = torch.empty(
             query.shape[:-1], dtype=torch.float32, device=query.device
         )
@@ -1312,6 +1314,8 @@ class FusedNeighborhoodAttention2D(Function):
         if bias is not None:
             bias = bias.to(query.dtype).contiguous()
         output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
         logsumexp = torch.empty(
             query.shape[:-1], dtype=torch.float32, device=query.device
         )
@@ -1449,6 +1453,8 @@ class FusedNeighborhoodAttention3D(Function):
         if bias is not None:
             bias = bias.to(query.dtype).contiguous()
         output = torch.empty_like(value)
+
+        # TODO: logsumexp should be conditional
         logsumexp = torch.empty(
             query.shape[:-1], dtype=torch.float32, device=query.device
         )

--- a/src/natten/na3d.py
+++ b/src/natten/na3d.py
@@ -27,6 +27,7 @@ from torch import nn, Tensor
 from torch.nn.init import trunc_normal_
 
 from .context import is_fna_enabled
+from .experimental import na3d as experimental_na3d
 from .functional import na3d, na3d_av, na3d_qk
 from .types import CausalArg3DTypeOrDed, Dimension3DTypeOrDed
 from .utils import check_all_args, log
@@ -51,6 +52,7 @@ class NeighborhoodAttention3D(nn.Module):
         qk_scale: Optional[float] = None,
         attn_drop: float = 0.0,
         proj_drop: float = 0.0,
+        use_experimental_ops: bool = False,
     ):
         super().__init__()
         kernel_size_, dilation_, is_causal_ = check_all_args(
@@ -88,6 +90,8 @@ class NeighborhoodAttention3D(nn.Module):
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
 
+        self.use_experimental_ops = use_experimental_ops
+
     def forward(self, x: Tensor) -> Tensor:
         if x.dim() != 5:
             raise ValueError(
@@ -111,7 +115,7 @@ class NeighborhoodAttention3D(nn.Module):
                 .permute(4, 0, 1, 2, 3, 5, 6)
             )
             q, k, v = qkv[0], qkv[1], qkv[2]
-            x = na3d(
+            x = (experimental_na3d if self.use_experimental_ops else na3d)(
                 q,
                 k,
                 v,
@@ -124,6 +128,10 @@ class NeighborhoodAttention3D(nn.Module):
             x = x.reshape(B, D, H, W, C)
 
         else:
+            if self.use_experimental_ops:
+                raise NotImplementedError(
+                    "Only fused NA is included in experimental support for torch.compile and torch's FLOP counter."
+                )
             qkv = (
                 self.qkv(x)
                 .reshape(B, D, H, W, 3, self.num_heads, self.head_dim)

--- a/src/natten/utils/checks.py
+++ b/src/natten/utils/checks.py
@@ -127,7 +127,9 @@ def check_tiling_config(na_dim: int, tiling_config: Any) -> FnaForwardConfigType
     if (
         isinstance(tiling_config, tuple)
         and len(tiling_config) == 2
-        and all(isinstance(x, tuple) and len(x) == na_dim for x in tiling_config)
+        and all(
+            isinstance(x, (tuple, list)) and len(x) == na_dim for x in tiling_config
+        )
     ):
         return tiling_config
     raise ValueError(
@@ -143,7 +145,9 @@ def check_backward_tiling_config(
     if (
         isinstance(tiling_config, tuple)
         and len(tiling_config) == 4
-        and all(isinstance(x, tuple) and len(x) == na_dim for x in tiling_config[:3])
+        and all(
+            isinstance(x, (tuple, list)) and len(x) == na_dim for x in tiling_config[:3]
+        )
         and isinstance(tiling_config[-1], bool)
     ):
         return tiling_config

--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -27,6 +27,10 @@ from torch.utils.cpp_extension import CUDA_HOME
 from .. import has_cuda, has_fna, has_fp64_gemm, has_gemm
 
 _SUPPORTS_NESTED = [int(x) for x in torch.__version__.split(".")[:2]] >= [2, 1]
+_SUPPORTS_EXPERIMENTAL_OPS = [int(x) for x in torch.__version__.split(".")[:2]] >= [
+    2,
+    4,
+]
 _IS_CUDA_AVAILABLE = (
     torch.cuda.is_available() and (CUDA_HOME is not None) and has_cuda()
 )
@@ -106,6 +110,21 @@ def skip_if_nested_is_not_supported():
             if not _SUPPORTS_NESTED:
                 self.skipTest(
                     "Nested tensors are not supported with this torch version."
+                )
+            else:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def skip_if_experimental_ops_are_not_supported():
+    def decorator(f):
+        def wrapper(self, *args, **kwargs):
+            if not _SUPPORTS_EXPERIMENTAL_OPS:
+                self.skipTest(
+                    "Experimental ops (registered with torch.library) are not supported with this torch version."
                 )
             else:
                 return f(self, *args, **kwargs)

--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -45,6 +45,15 @@ try:
 except ImportError:
     _IS_FVCORE_AVAILABLE = False
 
+try:
+    from xformers.ops.fmha import (  # type: ignore  # noqa: F401
+        memory_efficient_attention_partial,
+    )
+
+    _SUPPORTS_FNA_WITH_ADDITIONAL_KV = True
+except ImportError:
+    _SUPPORTS_FNA_WITH_ADDITIONAL_KV = False
+
 
 def skip_if_cuda_is_not_supported():
     def decorator(f):
@@ -145,3 +154,7 @@ def skip_if_fvcore_is_not_available():
         return wrapper
 
     return decorator
+
+
+def fna_supports_additional_kv():
+    return _SUPPORTS_FNA_WITH_ADDITIONAL_KV

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,204 @@
+#################################################################################################
+# Copyright (c) 2022-2024 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+
+import os
+import unittest
+
+import natten
+
+import torch
+from natten.utils.testing import (
+    skip_if_cuda_is_not_supported,
+    skip_if_experimental_ops_are_not_supported,
+    skip_if_fna_is_not_supported,
+)
+
+
+def _reset_everything():
+    natten.use_tiled_na()
+    natten.use_gemm_na()
+    natten.use_tf32_in_gemm_na()
+    natten.use_fused_na(False, kv_parallel=False)
+    os.environ["NATTEN_LOG_LEVEL"] = "CRITICAL"
+
+
+class TorchCompileTests(unittest.TestCase):
+    def setUp(self):
+        _reset_everything()
+
+    def tearDown(self):
+        _reset_everything()
+
+    def _build_model(
+        self,
+        dim_per_head,
+        heads,
+        kernel_size,
+        dilation,
+        is_causal,
+        qkv_bias,
+        use_experimental_ops,
+    ):
+        mod = natten.NeighborhoodAttention1D
+        if hasattr(kernel_size, "__len__") and len(kernel_size) == 2:
+            mod = natten.NeighborhoodAttention2D
+        elif hasattr(kernel_size, "__len__") and len(kernel_size) == 3:
+            mod = natten.NeighborhoodAttention3D
+
+        return mod(
+            dim=dim_per_head * heads,
+            num_heads=heads,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            qkv_bias=qkv_bias,
+            use_experimental_ops=use_experimental_ops,
+        ).cuda()
+
+    def _build_input(self, batch, spatial_extent, heads, dim_per_head):
+        shape = [batch, *spatial_extent, heads * dim_per_head]
+        return torch.randn(shape, device="cuda")
+
+    def _test_torch_compile(
+        self,
+        batch,
+        spatial_extent,
+        heads,
+        dim_per_head,
+        kernel_size,
+        dilation,
+        is_causal,
+        qkv_bias,
+        use_experimental_ops,
+    ):
+        m = self._build_model(
+            dim_per_head=dim_per_head,
+            heads=heads,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            is_causal=is_causal,
+            qkv_bias=qkv_bias,
+            use_experimental_ops=use_experimental_ops,
+        )
+        m_compiled = torch.compile(m, fullgraph=True)
+        x = self._build_input(
+            batch=batch,
+            spatial_extent=spatial_extent,
+            heads=heads,
+            dim_per_head=dim_per_head,
+        )
+
+        with torch.inference_mode():
+            _ = m_compiled(x)
+
+    # Expected failure since only experimental ops support torch.compile
+    @unittest.expectedFailure
+    @skip_if_experimental_ops_are_not_supported()
+    @skip_if_cuda_is_not_supported()
+    @skip_if_fna_is_not_supported()
+    def test_torch_compile_0(self):
+        natten.use_fused_na(False)
+
+        self._test_torch_compile(
+            batch=4,
+            spatial_extent=(128,),
+            heads=4,
+            dim_per_head=64,
+            kernel_size=(5,),
+            dilation=(2,),
+            is_causal=(False,),
+            qkv_bias=False,
+            use_experimental_ops=False,
+        )
+
+    # Expected failure since experimental ops only include FNA for now
+    @unittest.expectedFailure
+    @skip_if_experimental_ops_are_not_supported()
+    @skip_if_cuda_is_not_supported()
+    @skip_if_fna_is_not_supported()
+    def test_torch_compile_1(self):
+        natten.use_fused_na(False)
+
+        self._test_torch_compile(
+            batch=4,
+            spatial_extent=(128,),
+            heads=4,
+            dim_per_head=64,
+            kernel_size=(5,),
+            dilation=(2,),
+            is_causal=(False,),
+            qkv_bias=False,
+            use_experimental_ops=True,
+        )
+
+    # Expected failure since only experimental ops support torch.compile
+    @unittest.expectedFailure
+    @skip_if_experimental_ops_are_not_supported()
+    @skip_if_cuda_is_not_supported()
+    @skip_if_fna_is_not_supported()
+    def test_torch_compile_2(self):
+        natten.use_fused_na(True, kv_parallel=True)
+        self._test_torch_compile(
+            batch=4,
+            spatial_extent=(128,),
+            heads=4,
+            dim_per_head=64,
+            kernel_size=(5,),
+            dilation=(2,),
+            is_causal=(False,),
+            qkv_bias=False,
+            use_experimental_ops=False,
+        )
+
+    @skip_if_experimental_ops_are_not_supported()
+    @skip_if_cuda_is_not_supported()
+    @skip_if_fna_is_not_supported()
+    def test_torch_compile_3(self):
+        natten.use_fused_na(True, kv_parallel=True)
+        self._test_torch_compile(
+            batch=1,
+            spatial_extent=(16, 10),
+            heads=2,
+            dim_per_head=32,
+            kernel_size=(5, 3),
+            dilation=(2, 1),
+            is_causal=(False, False),
+            qkv_bias=True,
+            use_experimental_ops=True,
+        )
+
+        self._test_torch_compile(
+            batch=1,
+            spatial_extent=(6, 5, 8),
+            heads=2,
+            dim_per_head=32,
+            kernel_size=(5, 3, 7),
+            dilation=(1, 1, 1),
+            is_causal=(True, False, False),
+            qkv_bias=True,
+            use_experimental_ops=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fna1d.py
+++ b/tests/test_fna1d.py
@@ -36,6 +36,7 @@ from natten import (
 from natten.functional import na1d, na1d_av, na1d_qk
 from natten.utils import check_all_args
 from natten.utils.testing import (
+    fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
 )
@@ -316,6 +317,9 @@ class FNA1DTests(unittest.TestCase):
         is_causal=None,
         additional_kv_length=0,
     ):
+        if not fna_supports_additional_kv() and additional_kv_length > 0:
+            return
+
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
         assert not has_bias or not any(is_causal)
         inputs, reference = compute_bmm_reference(

--- a/tests/test_fna2d.py
+++ b/tests/test_fna2d.py
@@ -37,6 +37,7 @@ from natten import (
 from natten.functional import na2d, na2d_av, na2d_qk
 from natten.utils import check_all_args
 from natten.utils.testing import (
+    fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
 )
@@ -324,6 +325,9 @@ class FNA2DTests(unittest.TestCase):
         is_causal=None,
         additional_kv_length=0,
     ):
+        if not fna_supports_additional_kv() and additional_kv_length > 0:
+            return
+
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
         assert not has_bias or not any(is_causal)
         inputs, reference = compute_bmm_reference(

--- a/tests/test_fna3d.py
+++ b/tests/test_fna3d.py
@@ -37,6 +37,7 @@ from natten import (
 from natten.functional import na3d, na3d_av, na3d_qk
 from natten.utils import check_all_args
 from natten.utils.testing import (
+    fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
 )
@@ -327,6 +328,9 @@ class FNA3DTests(unittest.TestCase):
         is_causal=None,
         additional_kv_length=0,
     ):
+        if not fna_supports_additional_kv() and additional_kv_length > 0:
+            return
+
         kernel_size, dilation, is_causal = check_args(kernel_size, dilation, is_causal)
         assert not has_bias or not any(is_causal)
         inputs, reference = compute_bmm_reference(


### PR DESCRIPTION
See #184

Only supports forward pass for now, due to current limitations of registering custom ops with torch compared to autograd functions. Some of those limitations are:

* No stable interface for supporting autocasting to fp16/bf16,
  * Gradient scaling doesn't seem to be supported either, leading to training instability.

* Ops cannot indicate that they expect contiguous operands, and need to call `.contiguous()` within, and this incurs additional tensor copy costs, and brings down throughput (in some cases it's hard to even tell the difference between compiled and eager.)

- [x] Experimental torch ops (through torch.library; forward pass only)
- [x] FLOP counting per #184
- [x] Unit tests for FLOP counters
- [x] Confirm graph doesn't break -- (for some reason, when running with `torch.no_grad`, compiled graph isn't dumped to file with `TORCH_COMPILE_DEBUG=1`, but logs and assertions confirm it's working)
- [x] Check earlier torch versions to make sure nothing breaks, and unit tests pass
- [x] Unit test for torch.compile with fullgraph

