### PR TITLE
Fix flop tests

### DIFF
--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -33,6 +33,10 @@ _PYTHON_SUPPORTS_DYNAMO = [sys.version_info[0], sys.version_info[1]] < [3, 12]
 _IS_TORCH_COMPILE_SUPPORTED = _PYTHON_SUPPORTS_DYNAMO and [
     int(x) for x in torch.__version__.split(".")[:2]
 ] >= [2, 4]
+_IS_TORCH_FLOP_COUNT_SUPPORTED = [int(x) for x in torch.__version__.split(".")[:2]] >= [
+    2,
+    5,
+]
 
 _SUPPORTS_NESTED = [int(x) for x in torch.__version__.split(".")[:2]] >= [2, 1]
 _SUPPORTS_EXPERIMENTAL_OPS = [int(x) for x in torch.__version__.split(".")[:2]] >= [
@@ -166,6 +170,19 @@ def skip_if_torch_compile_is_not_supported():
         def wrapper(self, *args, **kwargs):
             if not _IS_TORCH_COMPILE_SUPPORTED:
                 self.skipTest("torch.compile is not supported.")
+            else:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def skip_if_torch_flop_count_is_not_supported():
+    def decorator(f):
+        def wrapper(self, *args, **kwargs):
+            if not _IS_TORCH_FLOP_COUNT_SUPPORTED:
+                self.skipTest("FLOP counting with torch is not supported.")
             else:
                 return f(self, *args, **kwargs)
 

--- a/tests/test_flops.py
+++ b/tests/test_flops.py
@@ -33,6 +33,7 @@ from natten.utils.testing import (
     skip_if_experimental_ops_are_not_supported,
     skip_if_fna_is_not_supported,
     skip_if_fvcore_is_not_available,
+    skip_if_torch_flop_count_is_not_supported,
 )
 
 
@@ -334,6 +335,7 @@ class FlopCounterTests(unittest.TestCase):
 
     # Expected failure since experimental ops only include FNA for now
     @unittest.expectedFailure
+    @skip_if_torch_flop_count_is_not_supported()
     @skip_if_experimental_ops_are_not_supported()
     def test_torch_flops_unfused(self):
         natten.use_fused_na(False, kv_parallel=False)
@@ -371,6 +373,7 @@ class FlopCounterTests(unittest.TestCase):
             qkv_bias=True,
         )
 
+    @skip_if_torch_flop_count_is_not_supported()
     @skip_if_experimental_ops_are_not_supported()
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()


### PR DESCRIPTION
Torch flop tests should only run on torch >= 2.5.