### PR TITLE
Disable invalid tests concerning older architectures

### DIFF
--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -40,7 +40,11 @@ _IS_TORCH_FLOP_COUNT_SUPPORTED = [int(x) for x in torch.__version__.split(".")[:
     2,
     5,
 ]
-_IS_TRITON_SUPPORTED = get_device_cc(0) >= 70
+
+# NOTE (ahassani): _IS_TRITON_SUPPORTED, `has_gemm`, `has_fp64_gemm`, and the like
+# all use the default CUDA device. This can break things on systems where there's
+# different archs available.
+_IS_TRITON_SUPPORTED = get_device_cc() >= 70
 
 _SUPPORTS_NESTED = [int(x) for x in torch.__version__.split(".")[:2]] >= [2, 1]
 _SUPPORTS_EXPERIMENTAL_OPS = [int(x) for x in torch.__version__.split(".")[:2]] >= [
@@ -173,7 +177,9 @@ def skip_if_triton_is_not_supported():
     def decorator(f):
         def wrapper(self, *args, **kwargs):
             if not _IS_TRITON_SUPPORTED:
-                self.skipTest("Triton is not supported.")
+                self.skipTest(
+                    "Triton is not supported on this GPU architecture (SM70 and above only)."
+                )
             else:
                 return f(self, *args, **kwargs)
 

--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -40,6 +40,7 @@ _IS_TORCH_FLOP_COUNT_SUPPORTED = [int(x) for x in torch.__version__.split(".")[:
     2,
     5,
 ]
+_IS_TRITON_SUPPORTED = get_device_cc(0) >= 70
 
 _SUPPORTS_NESTED = [int(x) for x in torch.__version__.split(".")[:2]] >= [2, 1]
 _SUPPORTS_EXPERIMENTAL_OPS = [int(x) for x in torch.__version__.split(".")[:2]] >= [
@@ -160,6 +161,19 @@ def skip_if_fvcore_is_not_available():
         def wrapper(self, *args, **kwargs):
             if not _IS_FVCORE_AVAILABLE:
                 self.skipTest("fvcore is not installed.")
+            else:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def skip_if_triton_is_not_supported():
+    def decorator(f):
+        def wrapper(self, *args, **kwargs):
+            if not _IS_TRITON_SUPPORTED:
+                self.skipTest("Triton is not supported.")
             else:
                 return f(self, *args, **kwargs)
 

--- a/src/natten/utils/testing.py
+++ b/src/natten/utils/testing.py
@@ -201,9 +201,16 @@ def fna_supports_additional_kv(
         return False
 
     device_cc = get_device_cc(device_index)
+
+    if device_cc < 80:
+        # xFormers FMHA API doesn't support returning LSE,
+        # so the only pre-Hopper choice winds up being FAv2, which is only SM80 and above.
+        return False
+
     if device_cc == 90 and head_dim not in [64, 128, 256]:
         # xFormers calls into FAv3, which only supports 64, 128, 256 headdim
         return False
+
     if device_cc > 90:
         # Blackwell status unclear
         return False

--- a/tests/test_fna1d.py
+++ b/tests/test_fna1d.py
@@ -40,6 +40,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
+    skip_if_torch_compile_is_not_supported,
 )
 
 
@@ -661,6 +662,7 @@ class FlexAttentionFNA1DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
+    @skip_if_torch_compile_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             (1, 1, 128, 16, 3, 1),

--- a/tests/test_fna1d.py
+++ b/tests/test_fna1d.py
@@ -40,7 +40,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
-    skip_if_torch_compile_is_not_supported,
+    skip_if_triton_is_not_supported,
 )
 
 
@@ -662,7 +662,7 @@ class FlexAttentionFNA1DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
-    @skip_if_torch_compile_is_not_supported()
+    @skip_if_triton_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             (1, 1, 128, 16, 3, 1),

--- a/tests/test_fna2d.py
+++ b/tests/test_fna2d.py
@@ -41,7 +41,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
-    skip_if_torch_compile_is_not_supported,
+    skip_if_triton_is_not_supported,
 )
 
 
@@ -687,7 +687,7 @@ class FlexAttentionFNA2DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
-    @skip_if_torch_compile_is_not_supported()
+    @skip_if_triton_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             # (akane):

--- a/tests/test_fna2d.py
+++ b/tests/test_fna2d.py
@@ -41,6 +41,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
+    skip_if_torch_compile_is_not_supported,
 )
 
 
@@ -686,6 +687,7 @@ class FlexAttentionFNA2DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
+    @skip_if_torch_compile_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             # (akane):

--- a/tests/test_fna3d.py
+++ b/tests/test_fna3d.py
@@ -41,7 +41,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
-    skip_if_torch_compile_is_not_supported,
+    skip_if_triton_is_not_supported,
 )
 
 
@@ -698,7 +698,7 @@ class FlexAttentionFNA3DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
-    @skip_if_torch_compile_is_not_supported()
+    @skip_if_triton_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             (1, 1, 8, 8, 4, 16, 3, 4, 3, 1, 1, 1),

--- a/tests/test_fna3d.py
+++ b/tests/test_fna3d.py
@@ -41,6 +41,7 @@ from natten.utils.testing import (
     fna_supports_additional_kv,
     skip_if_cuda_is_not_supported,
     skip_if_fna_is_not_supported,
+    skip_if_torch_compile_is_not_supported,
 )
 
 
@@ -697,6 +698,7 @@ class FlexAttentionFNA3DTest(unittest.TestCase):
 
     @skip_if_cuda_is_not_supported()
     @skip_if_fna_is_not_supported()
+    @skip_if_torch_compile_is_not_supported()
     def test_against_cutlass_fna(self):
         problem_sizes = [
             (1, 1, 8, 8, 4, 16, 3, 4, 3, 1, 1, 1),


### PR DESCRIPTION
@alihassanijr 
Minor bugfix to disable some unwanted unittests on particular hardware:
1. Disable extra KV tests where partial attention by FMHA is not available.
2. Disable Flex tests where triton is not available (i.e. cc<70).

Tested on:
✅ SM61
✅ SM75
✅ SM80
✅ SM86
✅ SM89   