### PR TITLE
Added external flash-attention backend for profiler

### DIFF
--- a/src/natten/profiler.py
+++ b/src/natten/profiler.py
@@ -55,7 +55,7 @@ __all__ = []  # type: ignore
 SUPPORTED_DTYPES = ["fp32", "bf16", "fp16"]
 NATTEN_BACKENDS = ["cutlass-fna", "blackwell-fna", "hopper-fna", "flex-fna"]
 NATTEN_FMHA_BACKENDS = ["cutlass-fmha", "blackwell-fmha", "hopper-fmha", "flex-fmha"]
-SDPA_BACKENDS = ["xformers", "cudnn", "fav2"]
+SDPA_BACKENDS = ["xformers", "cudnn", "fav2", "fa"]
 
 SCHEDULE_MAP = {
     "non": KernelSchedule.NonPersistent,

--- a/src/natten/profiling_utils/ops.py
+++ b/src/natten/profiling_utils/ops.py
@@ -27,9 +27,23 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 
 from torch.nn.functional import scaled_dot_product_attention
 
+try:
+    from flash_attn import flash_attn_func
+    HAS_FLASH_ATTN = True
+except ImportError:
+    from flash_attn_interface import flash_attn_func
+    HAS_FLASH_ATTN = True
+except:
+    HAS_FLASH_ATTN = False
 
 def sdpa(q: Tensor, k: Tensor, v: Tensor, backend: str) -> Tensor:
     backends = []
+
+    if backend == "fa":
+        if not HAS_FLASH_ATTN:
+            raise ValueError("Please install flash-attention before using `fa` backend.")
+
+        return flash_attn_func(q, k, v)
 
     if backend == "xformers":
         backends = [SDPBackend.EFFICIENT_ATTENTION]


### PR DESCRIPTION
The user can profile FMHA using flash-attention package provided they have either FAv2 or FAv3 installed.