### PR TITLE
Fix large-seq bugs in a few copy kernels

### DIFF
--- a/csrc/include/natten/cuda/fmha_blackwell/kernel/fmha_kernel_bwd_convert.hpp
+++ b/csrc/include/natten/cuda/fmha_blackwell/kernel/fmha_kernel_bwd_convert.hpp
@@ -100,12 +100,13 @@ struct FmhaKernelBwdConvert {
 
   static dim3 get_grid_shape(Params const& params) {
     dim3 grid(
-        size<4, 0>(params.problem_shape),
-        size<4, 1>(params.problem_shape),
+        // never put seq in z, long seqs can easily exceed the 64K limit
         ceil_div(
             std::max(
                 size<0>(params.problem_shape), size<1>(params.problem_shape)),
-            kBlockSeq));
+            kBlockSeq),
+        size<4, 0>(params.problem_shape),
+        size<4, 1>(params.problem_shape));
     return grid;
   }
 
@@ -129,25 +130,36 @@ struct FmhaKernelBwdConvert {
       StrideDest const& stride_dest,
       Count const& count,
       int d_dim) {
-    auto ptr_src_bh = ptr_src + get<2, 0, 0>(stride_src) * blockIdx.x +
-        get<2, 1>(stride_src) * blockIdx.y;
-    auto ptr_dest_bh = ptr_dest + get<2, 0, 0>(stride_dest) * blockIdx.x +
-        get<2, 1>(stride_dest) * blockIdx.y;
+    auto ptr_src_bh = ptr_src +
+        (static_cast<int64_t>(get<2, 0, 0>(stride_src)) *
+         static_cast<int64_t>(blockIdx.y)) +
+        (static_cast<int64_t>(get<2, 1>(stride_src)) *
+         static_cast<int64_t>(blockIdx.z));
+    auto ptr_dest_bh = ptr_dest +
+        (static_cast<int64_t>(get<2, 0, 0>(stride_dest)) *
+         static_cast<int64_t>(blockIdx.y)) +
+        (static_cast<int64_t>(get<2, 1>(stride_dest)) *
+         static_cast<int64_t>(blockIdx.z));
 
     int seqlen = count;
     if constexpr (is_variable_length_v<decltype(count)>) {
-      int offset = count.cumulative_length[blockIdx.y];
-      ptr_dest_bh += offset * get<0>(stride_dest);
-      seqlen = count.cumulative_length[blockIdx.y + 1] - offset;
+      int offset = count.cumulative_length[blockIdx.z];
+      ptr_dest_bh += static_cast<int64_t>(offset) *
+          static_cast<int64_t>(get<0>(stride_dest));
+      seqlen = count.cumulative_length[blockIdx.z + 1] - offset;
     }
 
     for (int idx_s_t = threadIdx.y; idx_s_t < kBlockSeq;
          idx_s_t += kNumThreadsSeq) {
-      int idx_s = idx_s_t + kBlockSeq * blockIdx.z;
+      int idx_s = idx_s_t + kBlockSeq * blockIdx.x;
       if (idx_s >= seqlen)
         continue;
-      auto ptr_src_bhs = ptr_src_bh + idx_s * get<0>(stride_src);
-      auto ptr_dest_bhs = ptr_dest_bh + idx_s * get<0>(stride_dest);
+      auto ptr_src_bhs = ptr_src_bh +
+          (static_cast<int64_t>(idx_s) *
+           static_cast<int64_t>(get<0>(stride_src)));
+      auto ptr_dest_bhs = ptr_dest_bh +
+          (static_cast<int64_t>(idx_s) *
+           static_cast<int64_t>(get<0>(stride_dest)));
 
       for (int idx_d = threadIdx.x * kElementsPerLoad; idx_d < d_dim;
            idx_d += kElementsPerLoad * kNumThreadsD) {


### PR DESCRIPTION
TokPerm kernel and blackwell backward copy kernel both put sequence in the y or z grid dimensions, both of which are capped at 64K. They must be in x to avoid overflows when we're dealing with large token counts.

Also fixes a potential offset overflow problem in blackwell copy kernel.