### PR TITLE
Add Metal (MPS) backend for neighborhood attention on Apple Silicon

### DIFF
--- a/csrc/src/metal_forward.mm
+++ b/csrc/src/metal_forward.mm
@@ -1,0 +1,4039 @@
+/**
+ * Metal Neighborhood Attention — Forward and Backward
+ *
+ * Tiled flash-attention forward and backward kernels for Apple Silicon (MPS).
+ * Supports 1D, 2D, and 3D neighborhood attention with FP32/FP16/BF16.
+ */
+
+#include <torch/extension.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/native/mps/OperationUtils.h>
+
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+#include <mutex>
+#include <atomic>
+#include <tuple>
+
+// =============================================================================
+// NAParams must match the Metal shader struct exactly
+// =============================================================================
+
+struct NAParams {
+    int32_t batch_size;
+    int32_t seqlen_q;
+    int32_t seqlen_kv;
+    int32_t heads_q;
+    int32_t heads_kv;
+    int32_t dim;
+    int32_t dim_value;
+    int32_t num_additional_kv;
+    float attn_scale;
+    int32_t na_dim;
+    int32_t qkv_shape[3];
+    int32_t window_size[3];
+    int32_t stride[3];
+    int32_t dilation[3];
+    int32_t is_causal[3];
+};
+
+// =============================================================================
+// Metal Kernel Source (embedded inline)
+// =============================================================================
+
+static NSString* get_metal_source() {
+    return @R"(
+#include <metal_stdlib>
+using namespace metal;
+
+struct NAParams {
+    int batch_size;
+    int seqlen_q;
+    int seqlen_kv;
+    int heads_q;
+    int heads_kv;
+    int dim;
+    int dim_value;
+    int num_additional_kv;
+    float attn_scale;
+    int na_dim;
+    int qkv_shape[3];
+    int window_size[3];
+    int stride[3];
+    int dilation[3];
+    int is_causal[3];
+};
+
+static inline int qkv_stride_fn(int na_dim, constant int* shape, int d) {
+    int s = 1;
+    for (int i = d + 1; i < na_dim; i++) {
+        s *= shape[i];
+    }
+    return s;
+}
+
+static inline void idx_to_coord(int idx, int na_dim, constant int* shape, thread int* coord) {
+    for (int d = 0; d < na_dim; d++) {
+        int s = qkv_stride_fn(na_dim, shape, d);
+        coord[d] = idx / s;
+        idx = idx % s;
+    }
+}
+
+static inline int qkv_fix_dilation(int qkv_shape, int dilation, int dilation_group) {
+    int padding = 1 - ((dilation_group + (dilation - (qkv_shape % dilation))) / dilation);
+    return (qkv_shape / dilation) + padding;
+}
+
+static inline int get_win_start_nc(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + (stride_val / 2), length - 1);
+    return max(stride_group_leader_idx - window_left, 0) +
+        ((stride_group_leader_idx + window_right >= length) *
+         (length - window_right - stride_group_leader_idx - 1));
+}
+
+static inline int get_win_start_causal(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + stride_val - 1, length - 1);
+    return max(stride_group_leader_idx - window_left - window_right, 0);
+}
+
+static inline int get_win_end_nc(int start, int window_size_val) {
+    return start + window_size_val;
+}
+
+static inline int get_win_end_causal(int index, int length) {
+    return min(index + 1, length);
+}
+
+static inline bool is_neighbor(int na_dim, thread int* kv_coord, thread int* win_start, thread int* win_end) {
+    for (int d = 0; d < na_dim; d++) {
+        if (kv_coord[d] < win_start[d] || kv_coord[d] >= win_end[d]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ======== FP32 Kernel ========
+
+kernel void na_forward_fp32(
+    device const float* Q        [[buffer(0)]],
+    device const float* K        [[buffer(1)]],
+    device const float* V        [[buffer(2)]],
+    device float* O              [[buffer(3)]],
+    device float* LSE            [[buffer(4)]],
+    constant NAParams& params    [[buffer(5)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+    int na_dim = params.na_dim;
+    int additional_kv_offset = SQ;
+
+    int q_coord_global[3] = {0, 0, 0};
+    idx_to_coord(idx_Q, na_dim, params.qkv_shape, q_coord_global);
+
+    int q_di_group[3], q_coord[3];
+    int corrected_shape[3];
+    for (int d = 0; d < na_dim; d++) {
+        q_di_group[d] = q_coord_global[d] % params.dilation[d];
+        q_coord[d] = q_coord_global[d] / params.dilation[d];
+        corrected_shape[d] = qkv_fix_dilation(params.qkv_shape[d], params.dilation[d], q_di_group[d]);
+    }
+
+    int win_start[3], win_end[3];
+    for (int d = 0; d < na_dim; d++) {
+        int wl = params.window_size[d] / 2;
+        int wr = (params.window_size[d] / 2) + ((params.window_size[d] % 2) - 1);
+        if (params.is_causal[d]) {
+            win_start[d] = get_win_start_causal(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_causal(q_coord[d], corrected_shape[d]);
+        } else {
+            win_start[d] = get_win_start_nc(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_nc(win_start[d], params.window_size[d]);
+        }
+    }
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+    threadgroup float shared_max;
+    threadgroup float shared_sum;
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            float acc = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            // SIMD vectorized Q*K dot product
+            int d4 = D / 4;
+            for (int d = 0; d < d4; d++) {
+                float4 q4 = *reinterpret_cast<device const float4*>(&Q[q_base + d * 4]);
+                float4 k4 = *reinterpret_cast<device const float4*>(&K[k_offset + d * 4]);
+                acc += dot(q4, k4);
+            }
+            for (int d = d4 * 4; d < D; d++) {
+                acc += Q[q_base + d] * K[k_offset + d];
+            }
+            acc *= params.attn_scale;
+
+            if (idx_K >= additional_kv_offset && idx_K - additional_kv_offset < params.num_additional_kv) {
+                // Additional KV token - always visible
+            } else if (idx_K >= additional_kv_offset) {
+                acc = -INFINITY;
+            } else {
+                int kv_coord_global[3] = {0, 0, 0};
+                idx_to_coord(idx_K, na_dim, params.qkv_shape, kv_coord_global);
+                int kv_di_group[3], kv_coord[3];
+                for (int d = 0; d < na_dim; d++) {
+                    kv_di_group[d] = kv_coord_global[d] % params.dilation[d];
+                    kv_coord[d] = kv_coord_global[d] / params.dilation[d];
+                }
+                bool di_match = true;
+                for (int d = 0; d < na_dim; d++) {
+                    if (q_di_group[d] != kv_di_group[d]) { di_match = false; break; }
+                }
+                if (!di_match || !is_neighbor(na_dim, kv_coord, win_start, win_end)) {
+                    acc = -INFINITY;
+                }
+            }
+            scores[idx_K - tile_offset] = acc;
+        }
+
+        float prev_max = running_max;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_max = max(running_max, scores[i]);
+            }
+            shared_max = running_max;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_max = shared_max;
+
+        if (running_max == -INFINITY) continue;
+
+        if (prev_max != -INFINITY) {
+            float correction = exp(prev_max - running_max);
+            running_sum *= correction;
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                final_acc[i] *= correction;
+            }
+        }
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            scores[idx_K - tile_offset] = exp(scores[idx_K - tile_offset] - running_max);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_sum += scores[i];
+            }
+            shared_sum = running_sum;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_sum = shared_sum;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+                    final_acc[i] += scores[j] * V[v_offset + idx_D];
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    int o_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    float scale_val = (running_sum > 0.0f) ? (1.0f / running_sum) : 0.0f;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < DV) {
+            O[o_base + idx_D] = final_acc[i] * scale_val;
+        }
+    }
+
+    if (tid == 0) {
+        int lse_idx = batch_idx * SQ * H + idx_Q * H + head_q_idx;
+        LSE[lse_idx] = log(running_sum) + running_max;
+    }
+}
+
+// ======== FP16 Kernel ========
+
+kernel void na_forward_fp16(
+    device const half* Q         [[buffer(0)]],
+    device const half* K         [[buffer(1)]],
+    device const half* V         [[buffer(2)]],
+    device half* O               [[buffer(3)]],
+    device float* LSE            [[buffer(4)]],
+    constant NAParams& params    [[buffer(5)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+    int na_dim = params.na_dim;
+    int additional_kv_offset = SQ;
+
+    int q_coord_global[3] = {0, 0, 0};
+    idx_to_coord(idx_Q, na_dim, params.qkv_shape, q_coord_global);
+
+    int q_di_group[3], q_coord[3];
+    int corrected_shape[3];
+    for (int d = 0; d < na_dim; d++) {
+        q_di_group[d] = q_coord_global[d] % params.dilation[d];
+        q_coord[d] = q_coord_global[d] / params.dilation[d];
+        corrected_shape[d] = qkv_fix_dilation(params.qkv_shape[d], params.dilation[d], q_di_group[d]);
+    }
+
+    int win_start[3], win_end[3];
+    for (int d = 0; d < na_dim; d++) {
+        int wl = params.window_size[d] / 2;
+        int wr = (params.window_size[d] / 2) + ((params.window_size[d] % 2) - 1);
+        if (params.is_causal[d]) {
+            win_start[d] = get_win_start_causal(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_causal(q_coord[d], corrected_shape[d]);
+        } else {
+            win_start[d] = get_win_start_nc(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_nc(win_start[d], params.window_size[d]);
+        }
+    }
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+    threadgroup float shared_max;
+    threadgroup float shared_sum;
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            float acc = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            // SIMD vectorized Q*K dot product (half4 -> float4)
+            int d4 = D / 4;
+            for (int d = 0; d < d4; d++) {
+                half4 q4 = *reinterpret_cast<device const half4*>(&Q[q_base + d * 4]);
+                half4 k4 = *reinterpret_cast<device const half4*>(&K[k_offset + d * 4]);
+                acc += dot(float4(q4), float4(k4));
+            }
+            for (int d = d4 * 4; d < D; d++) {
+                acc += float(Q[q_base + d]) * float(K[k_offset + d]);
+            }
+            acc *= params.attn_scale;
+
+            if (idx_K >= additional_kv_offset && idx_K - additional_kv_offset < params.num_additional_kv) {
+            } else if (idx_K >= additional_kv_offset) {
+                acc = -INFINITY;
+            } else {
+                int kv_coord_global[3] = {0, 0, 0};
+                idx_to_coord(idx_K, na_dim, params.qkv_shape, kv_coord_global);
+                int kv_di_group[3], kv_coord[3];
+                for (int d = 0; d < na_dim; d++) {
+                    kv_di_group[d] = kv_coord_global[d] % params.dilation[d];
+                    kv_coord[d] = kv_coord_global[d] / params.dilation[d];
+                }
+                bool di_match = true;
+                for (int d = 0; d < na_dim; d++) {
+                    if (q_di_group[d] != kv_di_group[d]) { di_match = false; break; }
+                }
+                if (!di_match || !is_neighbor(na_dim, kv_coord, win_start, win_end)) {
+                    acc = -INFINITY;
+                }
+            }
+            scores[idx_K - tile_offset] = acc;
+        }
+
+        float prev_max = running_max;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_max = max(running_max, scores[i]);
+            }
+            shared_max = running_max;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_max = shared_max;
+
+        if (running_max == -INFINITY) continue;
+
+        if (prev_max != -INFINITY) {
+            float correction = exp(prev_max - running_max);
+            running_sum *= correction;
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                final_acc[i] *= correction;
+            }
+        }
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            scores[idx_K - tile_offset] = exp(scores[idx_K - tile_offset] - running_max);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_sum += scores[i];
+            }
+            shared_sum = running_sum;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_sum = shared_sum;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+                    final_acc[i] += scores[j] * float(V[v_offset + idx_D]);
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    int o_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    float scale_val = (running_sum > 0.0f) ? (1.0f / running_sum) : 0.0f;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < DV) {
+            O[o_base + idx_D] = half(final_acc[i] * scale_val);
+        }
+    }
+
+    if (tid == 0) {
+        int lse_idx = batch_idx * SQ * H + idx_Q * H + head_q_idx;
+        LSE[lse_idx] = log(running_sum) + running_max;
+    }
+}
+
+// ======== BF16 Kernel ========
+
+kernel void na_forward_bf16(
+    device const bfloat* Q       [[buffer(0)]],
+    device const bfloat* K       [[buffer(1)]],
+    device const bfloat* V       [[buffer(2)]],
+    device bfloat* O             [[buffer(3)]],
+    device float* LSE            [[buffer(4)]],
+    constant NAParams& params    [[buffer(5)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+    int na_dim = params.na_dim;
+    int additional_kv_offset = SQ;
+
+    int q_coord_global[3] = {0, 0, 0};
+    idx_to_coord(idx_Q, na_dim, params.qkv_shape, q_coord_global);
+
+    int q_di_group[3], q_coord[3];
+    int corrected_shape[3];
+    for (int d = 0; d < na_dim; d++) {
+        q_di_group[d] = q_coord_global[d] % params.dilation[d];
+        q_coord[d] = q_coord_global[d] / params.dilation[d];
+        corrected_shape[d] = qkv_fix_dilation(params.qkv_shape[d], params.dilation[d], q_di_group[d]);
+    }
+
+    int win_start[3], win_end[3];
+    for (int d = 0; d < na_dim; d++) {
+        int wl = params.window_size[d] / 2;
+        int wr = (params.window_size[d] / 2) + ((params.window_size[d] % 2) - 1);
+        if (params.is_causal[d]) {
+            win_start[d] = get_win_start_causal(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_causal(q_coord[d], corrected_shape[d]);
+        } else {
+            win_start[d] = get_win_start_nc(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_nc(win_start[d], params.window_size[d]);
+        }
+    }
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+    threadgroup float shared_max;
+    threadgroup float shared_sum;
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            float acc = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            // SIMD vectorized Q*K dot product (bf16 -> float4)
+            int d4 = D / 4;
+            for (int d = 0; d < d4; d++) {
+                int base = d * 4;
+                float4 q4 = float4(float(Q[q_base + base]), float(Q[q_base + base + 1]),
+                                   float(Q[q_base + base + 2]), float(Q[q_base + base + 3]));
+                float4 k4 = float4(float(K[k_offset + base]), float(K[k_offset + base + 1]),
+                                   float(K[k_offset + base + 2]), float(K[k_offset + base + 3]));
+                acc += dot(q4, k4);
+            }
+            for (int d = d4 * 4; d < D; d++) {
+                acc += float(Q[q_base + d]) * float(K[k_offset + d]);
+            }
+            acc *= params.attn_scale;
+
+            if (idx_K >= additional_kv_offset && idx_K - additional_kv_offset < params.num_additional_kv) {
+            } else if (idx_K >= additional_kv_offset) {
+                acc = -INFINITY;
+            } else {
+                int kv_coord_global[3] = {0, 0, 0};
+                idx_to_coord(idx_K, na_dim, params.qkv_shape, kv_coord_global);
+                int kv_di_group[3], kv_coord[3];
+                for (int d = 0; d < na_dim; d++) {
+                    kv_di_group[d] = kv_coord_global[d] % params.dilation[d];
+                    kv_coord[d] = kv_coord_global[d] / params.dilation[d];
+                }
+                bool di_match = true;
+                for (int d = 0; d < na_dim; d++) {
+                    if (q_di_group[d] != kv_di_group[d]) { di_match = false; break; }
+                }
+                if (!di_match || !is_neighbor(na_dim, kv_coord, win_start, win_end)) {
+                    acc = -INFINITY;
+                }
+            }
+            scores[idx_K - tile_offset] = acc;
+        }
+
+        float prev_max = running_max;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_max = max(running_max, scores[i]);
+            }
+            shared_max = running_max;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_max = shared_max;
+
+        if (running_max == -INFINITY) continue;
+
+        if (prev_max != -INFINITY) {
+            float correction = exp(prev_max - running_max);
+            running_sum *= correction;
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                final_acc[i] *= correction;
+            }
+        }
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            scores[idx_K - tile_offset] = exp(scores[idx_K - tile_offset] - running_max);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tid == 0) {
+            for (int i = 0; i < tile_len; i++) {
+                running_sum += scores[i];
+            }
+            shared_sum = running_sum;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        running_sum = shared_sum;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+                    final_acc[i] += scores[j] * float(V[v_offset + idx_D]);
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    int o_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    float scale_val = (running_sum > 0.0f) ? (1.0f / running_sum) : 0.0f;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < DV) {
+            O[o_base + idx_D] = bfloat(final_acc[i] * scale_val);
+        }
+    }
+
+    if (tid == 0) {
+        int lse_idx = batch_idx * SQ * H + idx_Q * H + head_q_idx;
+        LSE[lse_idx] = log(running_sum) + running_max;
+    }
+}
+)";
+}
+
+// =============================================================================
+// Metal Tiled Forward Kernel Source (Flash-Attention style)
+// =============================================================================
+
+static NSString* get_metal_tiled_source() {
+    return @R"(
+#include <metal_stdlib>
+using namespace metal;
+
+struct NAParams {
+    int batch_size;
+    int seqlen_q;
+    int seqlen_kv;
+    int heads_q;
+    int heads_kv;
+    int dim;
+    int dim_value;
+    int num_additional_kv;
+    float attn_scale;
+    int na_dim;
+    int qkv_shape[3];
+    int window_size[3];
+    int stride[3];
+    int dilation[3];
+    int is_causal[3];
+};
+
+// Tiling constants - two presets dispatched based on head dimension D
+// Preset 0: D <= 64  -> Br=32, Bc=32
+// Preset 1: D <= 128 -> Br=16, Bc=32
+// D > 128 falls back to reference kernel (not dispatched here)
+//
+// Threadgroup: 256 threads = 8 simdgroups of 32
+// Each simdgroup owns Br/8 Q rows
+// Within a simdgroup, each lane handles 1 K position (32 lanes = Bc=32)
+
+constant constexpr int NUM_THREADS = 256;
+constant constexpr int SIMD_SIZE = 32;
+constant constexpr int NUM_SIMDGROUPS = NUM_THREADS / SIMD_SIZE;  // 8
+
+// Maximum head dim supported by tiled kernel
+constant constexpr int MAX_D_TILED = 128;
+
+// ---- Helper functions (same as reference kernel) ----
+
+static inline int qkv_stride_fn(int na_dim, constant int* shape, int d) {
+    int s = 1;
+    for (int i = d + 1; i < na_dim; i++) {
+        s *= shape[i];
+    }
+    return s;
+}
+
+static inline void idx_to_coord(int idx, int na_dim, constant int* shape, thread int* coord) {
+    for (int d = 0; d < na_dim; d++) {
+        int s = qkv_stride_fn(na_dim, shape, d);
+        coord[d] = idx / s;
+        idx = idx % s;
+    }
+}
+
+static inline int qkv_fix_dilation(int qkv_shape, int dilation, int dilation_group) {
+    int padding = 1 - ((dilation_group + (dilation - (qkv_shape % dilation))) / dilation);
+    return (qkv_shape / dilation) + padding;
+}
+
+static inline int get_win_start_nc(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + (stride_val / 2), length - 1);
+    return max(stride_group_leader_idx - window_left, 0) +
+        ((stride_group_leader_idx + window_right >= length) *
+         (length - window_right - stride_group_leader_idx - 1));
+}
+
+static inline int get_win_start_causal(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + stride_val - 1, length - 1);
+    return max(stride_group_leader_idx - window_left - window_right, 0);
+}
+
+static inline int get_win_end_nc(int start, int window_size_val) {
+    return start + window_size_val;
+}
+
+static inline int get_win_end_causal(int index, int length) {
+    return min(index + 1, length);
+}
+
+// Compute NA mask for a single Q-K pair (returns true if K is a valid neighbor)
+static inline bool compute_na_mask(
+    int q_idx, int k_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal
+) {
+    int q_coord_global[3] = {0, 0, 0};
+    int k_coord_global[3] = {0, 0, 0};
+
+    // idx_to_coord inline
+    {
+        int rem = q_idx;
+        for (int d = 0; d < na_dim; d++) {
+            int s = 1;
+            for (int i = d + 1; i < na_dim; i++) s *= qkv_shape[i];
+            q_coord_global[d] = rem / s;
+            rem = rem % s;
+        }
+    }
+    {
+        int rem = k_idx;
+        for (int d = 0; d < na_dim; d++) {
+            int s = 1;
+            for (int i = d + 1; i < na_dim; i++) s *= qkv_shape[i];
+            k_coord_global[d] = rem / s;
+            rem = rem % s;
+        }
+    }
+
+    for (int d = 0; d < na_dim; d++) {
+        int q_di = q_coord_global[d] % dilation_arr[d];
+        int k_di = k_coord_global[d] % dilation_arr[d];
+        if (q_di != k_di) return false;
+
+        int q_c = q_coord_global[d] / dilation_arr[d];
+        int k_c = k_coord_global[d] / dilation_arr[d];
+        int eff_len = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], q_di);
+
+        int wl = window_size[d] / 2;
+        int wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+
+        int ws, we;
+        if (is_causal[d]) {
+            ws = get_win_start_causal(q_c, wl, wr, stride_arr[d], eff_len);
+            we = get_win_end_causal(q_c, eff_len);
+        } else {
+            ws = get_win_start_nc(q_c, wl, wr, stride_arr[d], eff_len);
+            we = get_win_end_nc(ws, window_size[d]);
+        }
+
+        if (k_c < ws || k_c >= we) return false;
+    }
+    return true;
+}
+
+// Compute flattened KV range bounds for a single Q position
+// Returns (min_kv_flat, max_kv_flat) where max is exclusive
+static inline void compute_kv_bounds(
+    int q_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal,
+    thread int& min_kv, thread int& max_kv
+) {
+    int q_coord_global[3] = {0, 0, 0};
+    {
+        int rem = q_idx;
+        for (int d = 0; d < na_dim; d++) {
+            int s = 1;
+            for (int i = d + 1; i < na_dim; i++) s *= qkv_shape[i];
+            q_coord_global[d] = rem / s;
+            rem = rem % s;
+        }
+    }
+
+    // Compute per-dim window start/end in global coords, then flatten
+    int kv_start_coord[3] = {0, 0, 0};
+    int kv_end_coord[3] = {0, 0, 0};  // exclusive
+
+    for (int d = 0; d < na_dim; d++) {
+        int q_di = q_coord_global[d] % dilation_arr[d];
+        int q_c = q_coord_global[d] / dilation_arr[d];
+        int eff_len = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], q_di);
+
+        int wl = window_size[d] / 2;
+        int wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+
+        int ws, we;
+        if (is_causal[d]) {
+            ws = get_win_start_causal(q_c, wl, wr, stride_arr[d], eff_len);
+            we = get_win_end_causal(q_c, eff_len);
+        } else {
+            ws = get_win_start_nc(q_c, wl, wr, stride_arr[d], eff_len);
+            we = get_win_end_nc(ws, window_size[d]);
+        }
+
+        // Convert back to global coords
+        kv_start_coord[d] = ws * dilation_arr[d] + q_di;
+        // end is exclusive, last valid inner coord is (we-1), global = (we-1)*dil+di
+        kv_end_coord[d] = min((we - 1) * dilation_arr[d] + q_di + 1, qkv_shape[d]);
+    }
+
+    // Flatten start coord -> min flat index
+    min_kv = 0;
+    max_kv = 0;
+    for (int d = 0; d < na_dim; d++) {
+        int s = 1;
+        for (int i = d + 1; i < na_dim; i++) s *= qkv_shape[i];
+        min_kv += kv_start_coord[d] * s;
+        max_kv += (kv_end_coord[d] - 1) * s;
+    }
+    max_kv += 1;  // exclusive
+}
+
+// ---- Tiled Forward Kernel Macro ----
+// Parameters: FNAME=kernel name, DTYPE=buffer type, BR=Q tile rows, MAX_D=max head dim
+#define TILED_FWD_KERNEL(FNAME, DTYPE, BR, MAX_D) \
+kernel void FNAME( \
+    device const DTYPE* Q        [[buffer(0)]], \
+    device const DTYPE* K        [[buffer(1)]], \
+    device const DTYPE* V        [[buffer(2)]], \
+    device DTYPE* O              [[buffer(3)]], \
+    device float* LSE            [[buffer(4)]], \
+    constant NAParams& params    [[buffer(5)]], \
+    uint2 tgid                   [[threadgroup_position_in_grid]], \
+    uint tid                     [[thread_index_in_threadgroup]], \
+    uint simd_lane               [[thread_index_in_simdgroup]], \
+    uint simdgroup_id            [[simdgroup_index_in_threadgroup]] \
+) { \
+    constexpr int Br = BR; \
+    constexpr int Bc = 32; \
+    constexpr int ROWS_PER_SIMD = Br / NUM_SIMDGROUPS; \
+    \
+    int tile_q_start = (int)tgid.x * Br; \
+    int idx_L = (int)tgid.y; \
+    if (idx_L >= params.heads_q * params.batch_size) return; \
+    \
+    int batch_idx = idx_L / params.heads_q; \
+    int head_q_idx = idx_L % params.heads_q; \
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv); \
+    \
+    int SQ = params.seqlen_q; \
+    int SK = params.seqlen_kv; \
+    int D = params.dim; \
+    int DV = params.dim_value; \
+    int H = params.heads_q; \
+    int HK = params.heads_kv; \
+    int na_dim = params.na_dim; \
+    \
+    threadgroup float smem_K[Bc * MAX_D]; \
+    threadgroup float smem_V[Bc * MAX_D]; \
+    \
+    float q_reg[ROWS_PER_SIMD][MAX_D]; \
+    float o_acc[ROWS_PER_SIMD][MAX_D]; \
+    float row_max[ROWS_PER_SIMD]; \
+    float row_sum[ROWS_PER_SIMD]; \
+    int q_indices[ROWS_PER_SIMD]; \
+    \
+    for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+        int q_row = tile_q_start + (int)simdgroup_id * ROWS_PER_SIMD + r; \
+        q_indices[r] = q_row; \
+        row_max[r] = -INFINITY; \
+        row_sum[r] = 0.0f; \
+        for (int dd = 0; dd < MAX_D; dd++) { o_acc[r][dd] = 0.0f; q_reg[r][dd] = 0.0f; } \
+        if (q_row < SQ) { \
+            int q_base = batch_idx * SQ * H * D + q_row * H * D + head_q_idx * D; \
+            for (int dd = 0; dd < D; dd++) q_reg[r][dd] = float(Q[q_base + dd]); \
+        } \
+    } \
+    \
+    /* KV Bounding Box — as_type bit-cast through smem_K (no extra threadgroup memory) */ \
+    int first_tile, last_tile; \
+    { \
+        int local_min_kv = SK, local_max_kv = 0; \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int q_row = q_indices[r]; \
+            if (q_row < SQ) { \
+                int qmin, qmax; \
+                compute_kv_bounds(q_row, na_dim, params.qkv_shape, params.window_size, \
+                                  params.stride, params.dilation, params.is_causal, qmin, qmax); \
+                local_min_kv = min(local_min_kv, qmin); \
+                local_max_kv = max(local_max_kv, qmax); \
+            } \
+        } \
+        int sg_mn = simd_min(local_min_kv), sg_mx = simd_max(local_max_kv); \
+        if (simd_lane == 0) { \
+            smem_K[simdgroup_id * 2 + 0] = as_type<float>(sg_mn); \
+            smem_K[simdgroup_id * 2 + 1] = as_type<float>(sg_mx); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        int bbox_min_kv, bbox_max_kv; \
+        if (tid == 0) { \
+            bbox_min_kv = as_type<int>(smem_K[0]); \
+            bbox_max_kv = as_type<int>(smem_K[1]); \
+            for (int s = 1; s < NUM_SIMDGROUPS; s++) { \
+                bbox_min_kv = min(bbox_min_kv, as_type<int>(smem_K[s * 2])); \
+                bbox_max_kv = max(bbox_max_kv, as_type<int>(smem_K[s * 2 + 1])); \
+            } \
+            smem_K[0] = as_type<float>(bbox_min_kv); \
+            smem_K[1] = as_type<float>(bbox_max_kv); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        bbox_min_kv = as_type<int>(smem_K[0]); \
+        bbox_max_kv = as_type<int>(smem_K[1]); \
+        first_tile = bbox_min_kv / Bc; \
+        last_tile = min((bbox_max_kv + Bc - 1) / Bc, (SK + Bc - 1) / Bc); \
+    } \
+    int has_additional = params.num_additional_kv > 0 ? 1 : 0; \
+    int additional_first_tile = SQ / Bc; \
+    int additional_last_tile = (SQ + params.num_additional_kv + Bc - 1) / Bc; \
+    \
+    /* Main KV Tile Loop */ \
+    for (int tile_idx = first_tile; tile_idx < last_tile; tile_idx++) { \
+        int kv_start = tile_idx * Bc; \
+        int kv_end = min(kv_start + Bc, SK); \
+        int tile_len = kv_end - kv_start; \
+        \
+        /* Cooperative load K and V tiles */ \
+        int total_k = tile_len * D; \
+        for (int i = (int)tid; i < total_k; i += NUM_THREADS) { \
+            int kk = i / D, dd = i % D; \
+            smem_K[kk*D+dd] = float(K[batch_idx*SK*HK*D + (kv_start+kk)*HK*D + head_kv_idx*D + dd]); \
+        } \
+        int total_v = tile_len * DV; \
+        for (int i = (int)tid; i < total_v; i += NUM_THREADS) { \
+            int kk = i / DV, dd = i % DV; \
+            smem_V[kk*DV+dd] = float(V[batch_idx*SK*HK*DV + (kv_start+kk)*HK*DV + head_kv_idx*DV + dd]); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int q_row = q_indices[r]; \
+            if (q_row >= SQ) continue; \
+            \
+            float score = -INFINITY; \
+            int k_pos = (int)simd_lane; \
+            if (k_pos < tile_len) { \
+                int global_k = kv_start + k_pos; \
+                float acc = 0.0f; \
+                for (int dd = 0; dd < D; dd += 4) { \
+                    int rem = min(4, D - dd); \
+                    if (rem == 4) { \
+                        float4 q4 = float4(q_reg[r][dd], q_reg[r][dd+1], q_reg[r][dd+2], q_reg[r][dd+3]); \
+                        float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                        acc += dot(q4, k4); \
+                    } else { for (int ddd = 0; ddd < rem; ddd++) acc += q_reg[r][dd+ddd] * smem_K[k_pos*D+dd+ddd]; } \
+                } \
+                acc *= params.attn_scale; \
+                int additional_kv_offset = SQ; \
+                if (global_k >= additional_kv_offset && global_k - additional_kv_offset < params.num_additional_kv) { \
+                    score = acc; \
+                } else if (global_k >= additional_kv_offset) { \
+                    score = -INFINITY; \
+                } else { \
+                    bool is_nb = compute_na_mask(q_row, global_k, na_dim, \
+                                                  params.qkv_shape, params.window_size, \
+                                                  params.stride, params.dilation, params.is_causal); \
+                    score = is_nb ? acc : -INFINITY; \
+                } \
+            } \
+            \
+            float tile_max = simd_max(score); \
+            if (tile_max == -INFINITY) continue; \
+            if (tile_max > row_max[r]) { \
+                float correction = exp(row_max[r] - tile_max); \
+                row_sum[r] *= correction; \
+                for (int dd = 0; dd < DV; dd++) o_acc[r][dd] *= correction; \
+                row_max[r] = tile_max; \
+            } \
+            float exp_score = (score != -INFINITY) ? exp(score - row_max[r]) : 0.0f; \
+            row_sum[r] += simd_sum(exp_score); \
+            \
+            if (k_pos < tile_len) { \
+                for (int dd = 0; dd < DV; dd += 4) { \
+                    int rem = min(4, DV - dd); \
+                    if (rem == 4) { \
+                        float4 v4 = *reinterpret_cast<threadgroup const float4*>(&smem_V[k_pos*DV+dd]); \
+                        float4 w = exp_score * v4; \
+                        o_acc[r][dd] += simd_sum(w.x); o_acc[r][dd+1] += simd_sum(w.y); \
+                        o_acc[r][dd+2] += simd_sum(w.z); o_acc[r][dd+3] += simd_sum(w.w); \
+                    } else { for (int ddd = 0; ddd < rem; ddd++) o_acc[r][dd+ddd] += simd_sum(exp_score * smem_V[k_pos*DV+dd+ddd]); } \
+                } \
+            } else { \
+                for (int dd = 0; dd < DV; dd += 4) { \
+                    int rem = min(4, DV - dd); \
+                    if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } \
+                    else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } \
+                } \
+            } \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+    } \
+    \
+    /* Additional KV tiles */ \
+    if (has_additional) { \
+        for (int tile_idx = additional_first_tile; tile_idx < additional_last_tile; tile_idx++) { \
+            if (tile_idx >= first_tile && tile_idx < last_tile) continue; \
+            int kv_start = tile_idx * Bc; \
+            int kv_end = min(kv_start + Bc, SK); \
+            int tile_len = kv_end - kv_start; \
+            int total_k = tile_len * D; \
+            for (int i = (int)tid; i < total_k; i += NUM_THREADS) { \
+                int kk = i / D, dd = i % D; \
+                smem_K[kk*D+dd] = float(K[batch_idx*SK*HK*D + (kv_start+kk)*HK*D + head_kv_idx*D + dd]); \
+            } \
+            int total_v = tile_len * DV; \
+            for (int i = (int)tid; i < total_v; i += NUM_THREADS) { \
+                int kk = i / DV, dd = i % DV; \
+                smem_V[kk*DV+dd] = float(V[batch_idx*SK*HK*DV + (kv_start+kk)*HK*DV + head_kv_idx*DV + dd]); \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+            for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+                int q_row = q_indices[r]; \
+                if (q_row >= SQ) continue; \
+                float score = -INFINITY; \
+                int k_pos = (int)simd_lane; \
+                if (k_pos < tile_len) { \
+                    int global_k = kv_start + k_pos; \
+                    if (global_k >= SQ && global_k - SQ < params.num_additional_kv) { \
+                        float acc = 0.0f; \
+                        for (int dd = 0; dd < D; dd += 4) { \
+                            int rem = min(4, D - dd); \
+                            if (rem == 4) { \
+                                float4 q4 = float4(q_reg[r][dd], q_reg[r][dd+1], q_reg[r][dd+2], q_reg[r][dd+3]); \
+                                float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                                acc += dot(q4, k4); \
+                            } else { for (int ddd = 0; ddd < rem; ddd++) acc += q_reg[r][dd+ddd] * smem_K[k_pos*D+dd+ddd]; } \
+                        } \
+                        score = acc * params.attn_scale; \
+                    } \
+                } \
+                float tile_max = simd_max(score); \
+                if (tile_max == -INFINITY) continue; \
+                if (tile_max > row_max[r]) { \
+                    float correction = exp(row_max[r] - tile_max); \
+                    row_sum[r] *= correction; \
+                    for (int dd = 0; dd < DV; dd++) o_acc[r][dd] *= correction; \
+                    row_max[r] = tile_max; \
+                } \
+                float exp_score = (score != -INFINITY) ? exp(score - row_max[r]) : 0.0f; \
+                row_sum[r] += simd_sum(exp_score); \
+                if (k_pos < tile_len) { \
+                    for (int dd = 0; dd < DV; dd += 4) { \
+                        int rem = min(4, DV - dd); \
+                        if (rem == 4) { \
+                            float4 v4 = *reinterpret_cast<threadgroup const float4*>(&smem_V[k_pos*DV+dd]); \
+                            float4 w = exp_score * v4; \
+                            o_acc[r][dd] += simd_sum(w.x); o_acc[r][dd+1] += simd_sum(w.y); \
+                            o_acc[r][dd+2] += simd_sum(w.z); o_acc[r][dd+3] += simd_sum(w.w); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) o_acc[r][dd+ddd] += simd_sum(exp_score * smem_V[k_pos*DV+dd+ddd]); } \
+                    } \
+                } else { \
+                    for (int dd = 0; dd < DV; dd += 4) { \
+                        int rem = min(4, DV - dd); \
+                        if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } \
+                        else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } \
+                    } \
+                } \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+        } \
+    } \
+    \
+    /* Write output */ \
+    if (simd_lane == 0) { \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int q_row = q_indices[r]; \
+            if (q_row >= SQ) continue; \
+            int o_base = batch_idx * SQ * H * DV + q_row * H * DV + head_q_idx * DV; \
+            float s = (row_sum[r] > 0.0f) ? (1.0f / row_sum[r]) : 0.0f; \
+            for (int dd = 0; dd < DV; dd++) O[o_base + dd] = DTYPE(o_acc[r][dd] * s); \
+            LSE[batch_idx * SQ * H + q_row * H + head_q_idx] = log(row_sum[r]) + row_max[r]; \
+        } \
+    } \
+}
+
+TILED_FWD_KERNEL(na_forward_tiled_fp32_br32_d32, float, 32, 32)
+TILED_FWD_KERNEL(na_forward_tiled_fp32_br32, float, 32, 64)
+
+TILED_FWD_KERNEL(na_forward_tiled_fp32_br16, float, 16, 128)
+TILED_FWD_KERNEL(na_forward_tiled_fp16_br32_d32, half, 32, 32)
+TILED_FWD_KERNEL(na_forward_tiled_fp16_br32, half, 32, 64)
+TILED_FWD_KERNEL(na_forward_tiled_fp16_br16, half, 16, 128)
+TILED_FWD_KERNEL(na_forward_tiled_bf16_br32_d32, bfloat, 32, 32)
+TILED_FWD_KERNEL(na_forward_tiled_bf16_br32, bfloat, 32, 64)
+TILED_FWD_KERNEL(na_forward_tiled_bf16_br16, bfloat, 16, 128)
+
+)";
+}
+
+// =============================================================================
+// Metal Backward Kernel Source (embedded inline)
+// =============================================================================
+
+static NSString* get_metal_backward_source() {
+    return @R"(
+#include <metal_stdlib>
+using namespace metal;
+
+struct NAParams {
+    int batch_size;
+    int seqlen_q;
+    int seqlen_kv;
+    int heads_q;
+    int heads_kv;
+    int dim;
+    int dim_value;
+    int num_additional_kv;
+    float attn_scale;
+    int na_dim;
+    int qkv_shape[3];
+    int window_size[3];
+    int stride[3];
+    int dilation[3];
+    int is_causal[3];
+};
+
+static inline int qkv_stride_fn(int na_dim, constant int* shape, int d) {
+    int s = 1;
+    for (int i = d + 1; i < na_dim; i++) {
+        s *= shape[i];
+    }
+    return s;
+}
+
+static inline void idx_to_coord(int idx, int na_dim, constant int* shape, thread int* coord) {
+    for (int d = 0; d < na_dim; d++) {
+        int s = qkv_stride_fn(na_dim, shape, d);
+        coord[d] = idx / s;
+        idx = idx % s;
+    }
+}
+
+static inline int qkv_fix_dilation(int qkv_shape, int dilation, int dilation_group) {
+    int padding = 1 - ((dilation_group + (dilation - (qkv_shape % dilation))) / dilation);
+    return (qkv_shape / dilation) + padding;
+}
+
+static inline int get_win_start_nc(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + (stride_val / 2), length - 1);
+    return max(stride_group_leader_idx - window_left, 0) +
+        ((stride_group_leader_idx + window_right >= length) *
+         (length - window_right - stride_group_leader_idx - 1));
+}
+
+static inline int get_win_start_causal(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + stride_val - 1, length - 1);
+    return max(stride_group_leader_idx - window_left - window_right, 0);
+}
+
+static inline int get_win_end_nc(int start, int window_size_val) {
+    return start + window_size_val;
+}
+
+static inline int get_win_end_causal(int index, int length) {
+    return min(index + 1, length);
+}
+
+static inline bool is_neighbor(int na_dim, thread int* kv_coord, thread int* win_start, thread int* win_end) {
+    for (int d = 0; d < na_dim; d++) {
+        if (kv_coord[d] < win_start[d] || kv_coord[d] >= win_end[d]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Compute NA mask: returns true if (idx_Q, idx_K) is a valid neighbor pair
+static inline bool compute_na_mask(
+    int idx_Q, int idx_K, constant NAParams& params
+) {
+    int na_dim = params.na_dim;
+    int additional_kv_offset = params.seqlen_q;
+
+    // Additional KV tokens are always visible
+    if (idx_K >= additional_kv_offset && idx_K - additional_kv_offset < params.num_additional_kv) {
+        return true;
+    }
+    // Beyond additional KV range = invalid
+    if (idx_K >= additional_kv_offset) {
+        return false;
+    }
+
+    int q_coord_global[3] = {0, 0, 0};
+    idx_to_coord(idx_Q, na_dim, params.qkv_shape, q_coord_global);
+
+    int kv_coord_global[3] = {0, 0, 0};
+    idx_to_coord(idx_K, na_dim, params.qkv_shape, kv_coord_global);
+
+    int q_di_group[3], q_coord[3], kv_di_group[3], kv_coord[3];
+    int corrected_shape[3];
+    for (int d = 0; d < na_dim; d++) {
+        q_di_group[d] = q_coord_global[d] % params.dilation[d];
+        q_coord[d] = q_coord_global[d] / params.dilation[d];
+        kv_di_group[d] = kv_coord_global[d] % params.dilation[d];
+        kv_coord[d] = kv_coord_global[d] / params.dilation[d];
+        corrected_shape[d] = qkv_fix_dilation(params.qkv_shape[d], params.dilation[d], q_di_group[d]);
+    }
+
+    // Dilation group mismatch
+    for (int d = 0; d < na_dim; d++) {
+        if (q_di_group[d] != kv_di_group[d]) return false;
+    }
+
+    // Window check
+    int win_start[3], win_end[3];
+    for (int d = 0; d < na_dim; d++) {
+        int wl = params.window_size[d] / 2;
+        int wr = (params.window_size[d] / 2) + ((params.window_size[d] % 2) - 1);
+        if (params.is_causal[d]) {
+            win_start[d] = get_win_start_causal(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_causal(q_coord[d], corrected_shape[d]);
+        } else {
+            win_start[d] = get_win_start_nc(q_coord[d], wl, wr, params.stride[d], corrected_shape[d]);
+            win_end[d] = get_win_end_nc(win_start[d], params.window_size[d]);
+        }
+    }
+
+    return is_neighbor(na_dim, kv_coord, win_start, win_end);
+}
+
+// =============================================================================
+// dQ Backward Kernel — one threadgroup per Q position
+// =============================================================================
+
+kernel void na_backward_dQ_fp32(
+    device const float* Q        [[buffer(0)]],
+    device const float* K        [[buffer(1)]],
+    device const float* V        [[buffer(2)]],
+    device const float* O        [[buffer(3)]],
+    device const float* dO       [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device float* dQ             [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    int o_base = do_base;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            // Compute Q*K dot product (SIMD vectorized)
+            float acc_qk = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            { int d4 = D / 4;
+              for (int d = 0; d < d4; d++) {
+                  float4 q4 = *reinterpret_cast<device const float4*>(&Q[q_base + d * 4]);
+                  float4 k4 = *reinterpret_cast<device const float4*>(&K[k_offset + d * 4]);
+                  acc_qk += dot(q4, k4);
+              }
+              for (int d = d4 * 4; d < D; d++) acc_qk += Q[q_base + d] * K[k_offset + d];
+            }
+            acc_qk *= params.attn_scale;
+
+            // Compute dO*V dot product (SIMD vectorized)
+            float acc_dov = 0.0f;
+            int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  float4 do4 = *reinterpret_cast<device const float4*>(&dO[do_base + d * 4]);
+                  float4 v4 = *reinterpret_cast<device const float4*>(&V[v_offset + d * 4]);
+                  acc_dov += dot(do4, v4);
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_dov += dO[do_base + d] * V[v_offset + d];
+            }
+            acc_dov *= params.attn_scale;
+
+            // Compute dO*O dot product (SIMD vectorized)
+            float acc_doo = 0.0f;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  float4 do4 = *reinterpret_cast<device const float4*>(&dO[do_base + d * 4]);
+                  float4 o4 = *reinterpret_cast<device const float4*>(&O[o_base + d * 4]);
+                  acc_doo += dot(do4, o4);
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_doo += dO[do_base + d] * O[o_base + d];
+            }
+            acc_doo *= params.attn_scale;
+
+            // Apply NA mask
+            if (!compute_na_mask(idx_Q, idx_K, params)) {
+                acc_qk = -INFINITY;
+            }
+
+            scores[idx_K - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // Accumulate: dQ += scores[j] * K[j]
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+                    final_acc[i] += scores[j] * K[k_offset + idx_D];
+                }
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Write dQ
+    int dq_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < D) {
+            dQ[dq_base + idx_D] = final_acc[i];
+        }
+    }
+}
+
+// =============================================================================
+// dK Backward Kernel — one threadgroup per K position
+// =============================================================================
+
+kernel void na_backward_dK_fp32(
+    device const float* Q        [[buffer(0)]],
+    device const float* K        [[buffer(1)]],
+    device const float* V        [[buffer(2)]],
+    device const float* O        [[buffer(3)]],
+    device const float* dO       [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device float* dK             [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+    int v_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    // Iterate over all Q heads in the GQA group
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                int o_base = do_base;
+
+                // Q*K dot product (SIMD vectorized)
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      float4 q4 = *reinterpret_cast<device const float4*>(&Q[q_base + d * 4]);
+                      float4 k4 = *reinterpret_cast<device const float4*>(&K[k_base + d * 4]);
+                      acc_qk += dot(q4, k4);
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += Q[q_base + d] * K[k_base + d];
+                }
+                acc_qk *= params.attn_scale;
+
+                // dO*V dot product (SIMD vectorized)
+                float acc_dov = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      float4 do4 = *reinterpret_cast<device const float4*>(&dO[do_base + d * 4]);
+                      float4 v4 = *reinterpret_cast<device const float4*>(&V[v_base + d * 4]);
+                      acc_dov += dot(do4, v4);
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_dov += dO[do_base + d] * V[v_base + d];
+                }
+                acc_dov *= params.attn_scale;
+
+                // dO*O dot product (SIMD vectorized)
+                float acc_doo = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      float4 do4 = *reinterpret_cast<device const float4*>(&dO[do_base + d * 4]);
+                      float4 o4 = *reinterpret_cast<device const float4*>(&O[o_base + d * 4]);
+                      acc_doo += dot(do4, o4);
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_doo += dO[do_base + d] * O[o_base + d];
+                }
+                acc_doo *= params.attn_scale;
+
+                // Apply NA mask
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            // Accumulate: dK += scores[j] * Q[j]
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < D) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int q_offset = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                        final_acc[i] += scores[j] * Q[q_offset + idx_D];
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        // Accumulate into dK (additive across GQA heads)
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                if (gqa == 0) {
+                    dK[k_base + idx_D] = final_acc[i];
+                } else {
+                    dK[k_base + idx_D] += final_acc[i];
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// dV Backward Kernel — one threadgroup per K position
+// =============================================================================
+
+kernel void na_backward_dV_fp32(
+    device const float* Q        [[buffer(0)]],
+    device const float* K        [[buffer(1)]],
+    device const float* V        [[buffer(2)]],
+    device const float* O        [[buffer(3)]],
+    device const float* dO       [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device float* dV             [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    // Iterate over all Q heads in the GQA group
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+
+                // Q*K dot product (SIMD vectorized)
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      float4 q4 = *reinterpret_cast<device const float4*>(&Q[q_base + d * 4]);
+                      float4 k4 = *reinterpret_cast<device const float4*>(&K[k_base + d * 4]);
+                      acc_qk += dot(q4, k4);
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += Q[q_base + d] * K[k_base + d];
+                }
+                acc_qk *= params.attn_scale;
+
+                // Apply NA mask
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                // NOTE: dV uses only exp(qk - lse), no delta correction
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f));
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            // Accumulate: dV += scores[j] * dO[j]
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < DV) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int do_offset = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                        final_acc[i] += scores[j] * dO[do_offset + idx_D];
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        // Accumulate into dV (additive across GQA heads)
+        int dv_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                if (gqa == 0) {
+                    dV[dv_base + idx_D] = final_acc[i];
+                } else {
+                    dV[dv_base + idx_D] += final_acc[i];
+                }
+            }
+        }
+    }
+}
+
+// ======== FP16 Backward Kernels ========
+
+kernel void na_backward_dQ_fp16(
+    device const half* Q         [[buffer(0)]],
+    device const half* K         [[buffer(1)]],
+    device const half* V         [[buffer(2)]],
+    device const half* O         [[buffer(3)]],
+    device const half* dO        [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device half* dQ              [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    int o_base = do_base;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            // Q*K (SIMD vectorized half4 -> float4)
+            float acc_qk = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            { int d4 = D / 4;
+              for (int d = 0; d < d4; d++) {
+                  acc_qk += dot(float4(*reinterpret_cast<device const half4*>(&Q[q_base + d * 4])),
+                                float4(*reinterpret_cast<device const half4*>(&K[k_offset + d * 4])));
+              }
+              for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_offset + d]);
+            }
+            acc_qk *= params.attn_scale;
+
+            // dO*V (SIMD vectorized)
+            float acc_dov = 0.0f;
+            int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  acc_dov += dot(float4(*reinterpret_cast<device const half4*>(&dO[do_base + d * 4])),
+                                 float4(*reinterpret_cast<device const half4*>(&V[v_offset + d * 4])));
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_dov += float(dO[do_base + d]) * float(V[v_offset + d]);
+            }
+            acc_dov *= params.attn_scale;
+
+            // dO*O (SIMD vectorized)
+            float acc_doo = 0.0f;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  acc_doo += dot(float4(*reinterpret_cast<device const half4*>(&dO[do_base + d * 4])),
+                                 float4(*reinterpret_cast<device const half4*>(&O[o_base + d * 4])));
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_doo += float(dO[do_base + d]) * float(O[o_base + d]);
+            }
+            acc_doo *= params.attn_scale;
+
+            if (!compute_na_mask(idx_Q, idx_K, params)) {
+                acc_qk = -INFINITY;
+            }
+
+            scores[idx_K - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+                    final_acc[i] += scores[j] * float(K[k_offset + idx_D]);
+                }
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    int dq_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < D) {
+            dQ[dq_base + idx_D] = half(final_acc[i]);
+        }
+    }
+}
+
+kernel void na_backward_dK_fp16(
+    device const half* Q         [[buffer(0)]],
+    device const half* K         [[buffer(1)]],
+    device const half* V         [[buffer(2)]],
+    device const half* O         [[buffer(3)]],
+    device const half* dO        [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device half* dK              [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+    int v_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                int o_base = do_base;
+
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      acc_qk += dot(float4(*reinterpret_cast<device const half4*>(&Q[q_base + d * 4])),
+                                    float4(*reinterpret_cast<device const half4*>(&K[k_base + d * 4])));
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_base + d]);
+                }
+                acc_qk *= params.attn_scale;
+
+                float acc_dov = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      acc_dov += dot(float4(*reinterpret_cast<device const half4*>(&dO[do_base + d * 4])),
+                                     float4(*reinterpret_cast<device const half4*>(&V[v_base + d * 4])));
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_dov += float(dO[do_base + d]) * float(V[v_base + d]);
+                }
+                acc_dov *= params.attn_scale;
+
+                float acc_doo = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      acc_doo += dot(float4(*reinterpret_cast<device const half4*>(&dO[do_base + d * 4])),
+                                     float4(*reinterpret_cast<device const half4*>(&O[o_base + d * 4])));
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_doo += float(dO[do_base + d]) * float(O[o_base + d]);
+                }
+                acc_doo *= params.attn_scale;
+
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < D) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int q_offset = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                        final_acc[i] += scores[j] * float(Q[q_offset + idx_D]);
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                if (gqa == 0) {
+                    dK[k_base + idx_D] = half(final_acc[i]);
+                } else {
+                    dK[k_base + idx_D] = half(float(dK[k_base + idx_D]) + final_acc[i]);
+                }
+            }
+        }
+    }
+}
+
+kernel void na_backward_dV_fp16(
+    device const half* Q         [[buffer(0)]],
+    device const half* K         [[buffer(1)]],
+    device const half* V         [[buffer(2)]],
+    device const half* O         [[buffer(3)]],
+    device const half* dO        [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device half* dV              [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      acc_qk += dot(float4(*reinterpret_cast<device const half4*>(&Q[q_base + d * 4])),
+                                    float4(*reinterpret_cast<device const half4*>(&K[k_base + d * 4])));
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_base + d]);
+                }
+                acc_qk *= params.attn_scale;
+
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f));
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < DV) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int do_offset = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                        final_acc[i] += scores[j] * float(dO[do_offset + idx_D]);
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        int dv_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                if (gqa == 0) {
+                    dV[dv_base + idx_D] = half(final_acc[i]);
+                } else {
+                    dV[dv_base + idx_D] = half(float(dV[dv_base + idx_D]) + final_acc[i]);
+                }
+            }
+        }
+    }
+}
+
+// ======== BF16 Backward Kernels ========
+
+kernel void na_backward_dQ_bf16(
+    device const bfloat* Q       [[buffer(0)]],
+    device const bfloat* K       [[buffer(1)]],
+    device const bfloat* V       [[buffer(2)]],
+    device const bfloat* O       [[buffer(3)]],
+    device const bfloat* dO      [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device bfloat* dQ            [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_Q = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_Q >= params.seqlen_q) return;
+    if (idx_L >= params.heads_q * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_q;
+    int head_q_idx = idx_L % params.heads_q;
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv);
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+    int o_base = do_base;
+    int k_batch_offset = batch_idx * SK * HK * D;
+    int k_head_offset = head_kv_idx * D;
+    int v_batch_offset = batch_idx * SK * HK * DV;
+    int v_head_offset = head_kv_idx * DV;
+
+    float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+
+    constexpr int KV_TILE_SIZE = 2048;
+    threadgroup float scores[KV_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+    for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+    int num_kv_tiles = (SK + KV_TILE_SIZE - 1) / KV_TILE_SIZE;
+
+    for (int tile = 0; tile < num_kv_tiles; tile++) {
+        int tile_offset = tile * KV_TILE_SIZE;
+        int tile_end = min(tile_offset + KV_TILE_SIZE, SK);
+        int tile_len = tile_end - tile_offset;
+
+        for (int idx_K = tile_offset + (int)tid; idx_K < tile_end; idx_K += (int)NUM_THREADS) {
+            float acc_qk = 0.0f;
+            int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+            { int d4 = D / 4;
+              for (int d = 0; d < d4; d++) {
+                  int base = d * 4;
+                  float4 q4 = float4(float(Q[q_base + base]), float(Q[q_base + base + 1]),
+                                     float(Q[q_base + base + 2]), float(Q[q_base + base + 3]));
+                  float4 k4 = float4(float(K[k_offset + base]), float(K[k_offset + base + 1]),
+                                     float(K[k_offset + base + 2]), float(K[k_offset + base + 3]));
+                  acc_qk += dot(q4, k4);
+              }
+              for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_offset + d]);
+            }
+            acc_qk *= params.attn_scale;
+
+            float acc_dov = 0.0f;
+            int v_offset = v_batch_offset + idx_K * HK * DV + v_head_offset;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  int base = d * 4;
+                  float4 do4 = float4(float(dO[do_base + base]), float(dO[do_base + base + 1]),
+                                      float(dO[do_base + base + 2]), float(dO[do_base + base + 3]));
+                  float4 v4 = float4(float(V[v_offset + base]), float(V[v_offset + base + 1]),
+                                     float(V[v_offset + base + 2]), float(V[v_offset + base + 3]));
+                  acc_dov += dot(do4, v4);
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_dov += float(dO[do_base + d]) * float(V[v_offset + d]);
+            }
+            acc_dov *= params.attn_scale;
+
+            float acc_doo = 0.0f;
+            { int d4 = DV / 4;
+              for (int d = 0; d < d4; d++) {
+                  int base = d * 4;
+                  float4 do4 = float4(float(dO[do_base + base]), float(dO[do_base + base + 1]),
+                                      float(dO[do_base + base + 2]), float(dO[do_base + base + 3]));
+                  float4 o4 = float4(float(O[o_base + base]), float(O[o_base + base + 1]),
+                                     float(O[o_base + base + 2]), float(O[o_base + base + 3]));
+                  acc_doo += dot(do4, o4);
+              }
+              for (int d = d4 * 4; d < DV; d++) acc_doo += float(dO[do_base + d]) * float(O[o_base + d]);
+            }
+            acc_doo *= params.attn_scale;
+
+            if (!compute_na_mask(idx_Q, idx_K, params)) {
+                acc_qk = -INFINITY;
+            }
+
+            scores[idx_K - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                for (int j = 0; j < tile_len; j++) {
+                    int idx_K = j + tile_offset;
+                    int k_offset = k_batch_offset + idx_K * HK * D + k_head_offset;
+                    final_acc[i] += scores[j] * float(K[k_offset + idx_D]);
+                }
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    int dq_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+    for (int i = 0; i < DIM_PER_THREAD; i++) {
+        int idx_D = tid + i * NUM_THREADS;
+        if (idx_D < D) {
+            dQ[dq_base + idx_D] = bfloat(final_acc[i]);
+        }
+    }
+}
+
+kernel void na_backward_dK_bf16(
+    device const bfloat* Q       [[buffer(0)]],
+    device const bfloat* K       [[buffer(1)]],
+    device const bfloat* V       [[buffer(2)]],
+    device const bfloat* O       [[buffer(3)]],
+    device const bfloat* dO      [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device bfloat* dK            [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+    int v_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                int do_base = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                int o_base = do_base;
+
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      int base = d * 4;
+                      float4 q4 = float4(float(Q[q_base + base]), float(Q[q_base + base + 1]),
+                                         float(Q[q_base + base + 2]), float(Q[q_base + base + 3]));
+                      float4 k4 = float4(float(K[k_base + base]), float(K[k_base + base + 1]),
+                                         float(K[k_base + base + 2]), float(K[k_base + base + 3]));
+                      acc_qk += dot(q4, k4);
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_base + d]);
+                }
+                acc_qk *= params.attn_scale;
+
+                float acc_dov = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      int base = d * 4;
+                      float4 do4 = float4(float(dO[do_base + base]), float(dO[do_base + base + 1]),
+                                          float(dO[do_base + base + 2]), float(dO[do_base + base + 3]));
+                      float4 v4 = float4(float(V[v_base + base]), float(V[v_base + base + 1]),
+                                         float(V[v_base + base + 2]), float(V[v_base + base + 3]));
+                      acc_dov += dot(do4, v4);
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_dov += float(dO[do_base + d]) * float(V[v_base + d]);
+                }
+                acc_dov *= params.attn_scale;
+
+                float acc_doo = 0.0f;
+                { int d4 = DV / 4;
+                  for (int d = 0; d < d4; d++) {
+                      int base = d * 4;
+                      float4 do4 = float4(float(dO[do_base + base]), float(dO[do_base + base + 1]),
+                                          float(dO[do_base + base + 2]), float(dO[do_base + base + 3]));
+                      float4 o4 = float4(float(O[o_base + base]), float(O[o_base + base + 1]),
+                                         float(O[o_base + base + 2]), float(O[o_base + base + 3]));
+                      acc_doo += dot(do4, o4);
+                  }
+                  for (int d = d4 * 4; d < DV; d++) acc_doo += float(dO[do_base + d]) * float(O[o_base + d]);
+                }
+                acc_doo *= params.attn_scale;
+
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f)) * (acc_dov - acc_doo);
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < D) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int q_offset = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+                        final_acc[i] += scores[j] * float(Q[q_offset + idx_D]);
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < D) {
+                if (gqa == 0) {
+                    dK[k_base + idx_D] = bfloat(final_acc[i]);
+                } else {
+                    dK[k_base + idx_D] = bfloat(float(dK[k_base + idx_D]) + final_acc[i]);
+                }
+            }
+        }
+    }
+}
+
+kernel void na_backward_dV_bf16(
+    device const bfloat* Q       [[buffer(0)]],
+    device const bfloat* K       [[buffer(1)]],
+    device const bfloat* V       [[buffer(2)]],
+    device const bfloat* O       [[buffer(3)]],
+    device const bfloat* dO      [[buffer(4)]],
+    device const float* LSE      [[buffer(5)]],
+    device bfloat* dV            [[buffer(6)]],
+    constant NAParams& params    [[buffer(7)]],
+    uint2 tgid                   [[threadgroup_position_in_grid]],
+    uint tid                     [[thread_index_in_threadgroup]]
+) {
+    int idx_K = tgid.x;
+    int idx_L = tgid.y;
+
+    if (idx_K >= params.seqlen_kv) return;
+    if (idx_L >= params.heads_kv * params.batch_size) return;
+
+    int batch_idx = idx_L / params.heads_kv;
+    int head_kv_idx = idx_L % params.heads_kv;
+    int gqa_ratio = params.heads_q / params.heads_kv;
+
+    int SQ = params.seqlen_q;
+    int SK = params.seqlen_kv;
+    int D = params.dim;
+    int DV = params.dim_value;
+    int H = params.heads_q;
+    int HK = params.heads_kv;
+
+    int k_base = batch_idx * SK * HK * D + idx_K * HK * D + head_kv_idx * D;
+
+    constexpr int Q_TILE_SIZE = 2048;
+    threadgroup float scores[Q_TILE_SIZE];
+
+    constexpr int MAX_DIM = 1024;
+    constexpr int NUM_THREADS = 256;
+    constexpr int DIM_PER_THREAD = MAX_DIM / NUM_THREADS;
+    float final_acc[DIM_PER_THREAD];
+
+    int num_q_tiles = (SQ + Q_TILE_SIZE - 1) / Q_TILE_SIZE;
+
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) {
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa;
+
+        for (int i = 0; i < DIM_PER_THREAD; i++) final_acc[i] = 0.0f;
+
+        for (int tile = 0; tile < num_q_tiles; tile++) {
+            int tile_offset = tile * Q_TILE_SIZE;
+            int tile_end = min(tile_offset + Q_TILE_SIZE, SQ);
+            int tile_len = tile_end - tile_offset;
+
+            for (int idx_Q = tile_offset + (int)tid; idx_Q < tile_end; idx_Q += (int)NUM_THREADS) {
+                int q_base = batch_idx * SQ * H * D + idx_Q * H * D + head_q_idx * D;
+
+                float acc_qk = 0.0f;
+                { int d4 = D / 4;
+                  for (int d = 0; d < d4; d++) {
+                      int base = d * 4;
+                      float4 q4 = float4(float(Q[q_base + base]), float(Q[q_base + base + 1]),
+                                         float(Q[q_base + base + 2]), float(Q[q_base + base + 3]));
+                      float4 k4 = float4(float(K[k_base + base]), float(K[k_base + base + 1]),
+                                         float(K[k_base + base + 2]), float(K[k_base + base + 3]));
+                      acc_qk += dot(q4, k4);
+                  }
+                  for (int d = d4 * 4; d < D; d++) acc_qk += float(Q[q_base + d]) * float(K[k_base + d]);
+                }
+                acc_qk *= params.attn_scale;
+
+                if (!compute_na_mask(idx_Q, idx_K, params)) {
+                    acc_qk = -INFINITY;
+                }
+
+                float lse_val = LSE[batch_idx * SQ * H + idx_Q * H + head_q_idx];
+                scores[idx_Q - tile_offset] = exp(min(acc_qk - lse_val, 0.0f));
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int i = 0; i < DIM_PER_THREAD; i++) {
+                int idx_D = tid + i * NUM_THREADS;
+                if (idx_D < DV) {
+                    for (int j = 0; j < tile_len; j++) {
+                        int idx_Q = j + tile_offset;
+                        int do_offset = batch_idx * SQ * H * DV + idx_Q * H * DV + head_q_idx * DV;
+                        final_acc[i] += scores[j] * float(dO[do_offset + idx_D]);
+                    }
+                }
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        int dv_base = batch_idx * SK * HK * DV + idx_K * HK * DV + head_kv_idx * DV;
+        for (int i = 0; i < DIM_PER_THREAD; i++) {
+            int idx_D = tid + i * NUM_THREADS;
+            if (idx_D < DV) {
+                if (gqa == 0) {
+                    dV[dv_base + idx_D] = bfloat(final_acc[i]);
+                } else {
+                    dV[dv_base + idx_D] = bfloat(float(dV[dv_base + idx_D]) + final_acc[i]);
+                }
+            }
+        }
+    }
+}
+
+)";
+}
+
+// =============================================================================
+// Metal Tiled Backward Kernel Source (Flash-Attention style backward)
+// =============================================================================
+
+static NSString* get_metal_tiled_backward_source() {
+    return @R"(
+#include <metal_stdlib>
+using namespace metal;
+
+struct NAParams {
+    int batch_size;
+    int seqlen_q;
+    int seqlen_kv;
+    int heads_q;
+    int heads_kv;
+    int dim;
+    int dim_value;
+    int num_additional_kv;
+    float attn_scale;
+    int na_dim;
+    int qkv_shape[3];
+    int window_size[3];
+    int stride[3];
+    int dilation[3];
+    int is_causal[3];
+};
+
+constant constexpr int NUM_THREADS = 256;
+constant constexpr int SIMD_SIZE = 32;
+constant constexpr int NUM_SIMDGROUPS = NUM_THREADS / SIMD_SIZE;  // 8
+
+// ---- Helper functions ----
+
+static inline int qkv_stride_fn(int na_dim, constant int* shape, int d) {
+    int s = 1;
+    for (int i = d + 1; i < na_dim; i++) s *= shape[i];
+    return s;
+}
+
+static inline void idx_to_coord(int idx, int na_dim, constant int* shape, thread int* coord) {
+    for (int d = 0; d < na_dim; d++) {
+        int s = qkv_stride_fn(na_dim, shape, d);
+        coord[d] = idx / s;
+        idx = idx % s;
+    }
+}
+
+static inline int qkv_fix_dilation(int qkv_shape, int dilation, int dilation_group) {
+    int padding = 1 - ((dilation_group + (dilation - (qkv_shape % dilation))) / dilation);
+    return (qkv_shape / dilation) + padding;
+}
+
+static inline int get_win_start_nc(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + (stride_val / 2), length - 1);
+    return max(stride_group_leader_idx - window_left, 0) +
+        ((stride_group_leader_idx + window_right >= length) *
+         (length - window_right - stride_group_leader_idx - 1));
+}
+
+static inline int get_win_start_causal(int index, int window_left, int window_right, int stride_val, int length) {
+    int stride_group_leader_idx = min((index / stride_val) * stride_val + stride_val - 1, length - 1);
+    return max(stride_group_leader_idx - window_left - window_right, 0);
+}
+
+static inline int get_win_end_nc(int start, int window_size_val) {
+    return start + window_size_val;
+}
+
+static inline int get_win_end_causal(int index, int length) {
+    return min(index + 1, length);
+}
+
+static inline bool compute_na_mask(
+    int q_idx, int k_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal
+) {
+    int q_cg[3] = {0,0,0}, k_cg[3] = {0,0,0};
+    { int rem = q_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; q_cg[d] = rem / s; rem = rem % s; } }
+    { int rem = k_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; k_cg[d] = rem / s; rem = rem % s; } }
+    for (int d = 0; d < na_dim; d++) {
+        int q_di = q_cg[d] % dilation_arr[d], k_di = k_cg[d] % dilation_arr[d];
+        if (q_di != k_di) return false;
+        int q_c = q_cg[d] / dilation_arr[d], k_c = k_cg[d] / dilation_arr[d];
+        int eff = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], q_di);
+        int wl = window_size[d] / 2, wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+        int ws, we;
+        if (is_causal[d]) { ws = get_win_start_causal(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_causal(q_c, eff); }
+        else { ws = get_win_start_nc(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_nc(ws, window_size[d]); }
+        if (k_c < ws || k_c >= we) return false;
+    }
+    return true;
+}
+
+// Precompute per-dim window bounds for a Q position.
+// Stores q_di_group[d], win_start_global[d], win_end_global[d] (in global coords)
+// so that K neighbor check becomes a simple coord range test.
+static inline void precompute_q_window(
+    int q_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal,
+    thread int* q_di_out, thread int* win_start_global, thread int* win_end_global
+) {
+    int q_cg[3] = {0,0,0};
+    { int rem = q_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; q_cg[d] = rem / s; rem = rem % s; } }
+    for (int d = 0; d < na_dim; d++) {
+        int q_di = q_cg[d] % dilation_arr[d];
+        int q_c = q_cg[d] / dilation_arr[d];
+        int eff = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], q_di);
+        int wl = window_size[d] / 2, wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+        int ws, we;
+        if (is_causal[d]) { ws = get_win_start_causal(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_causal(q_c, eff); }
+        else { ws = get_win_start_nc(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_nc(ws, window_size[d]); }
+        q_di_out[d] = q_di;
+        win_start_global[d] = ws * dilation_arr[d] + q_di;
+        win_end_global[d] = min((we - 1) * dilation_arr[d] + q_di + 1, qkv_shape[d]);
+    }
+}
+
+// Fast neighbor check using precomputed Q window bounds.
+// Only needs idx_to_coord for K (no window computation).
+static inline bool check_na_window(
+    int k_idx, int na_dim,
+    constant int* qkv_shape, constant int* dilation_arr,
+    thread int* q_di, thread int* win_start_global, thread int* win_end_global
+) {
+    int k_cg[3] = {0,0,0};
+    { int rem = k_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; k_cg[d] = rem / s; rem = rem % s; } }
+    for (int d = 0; d < na_dim; d++) {
+        if (k_cg[d] % dilation_arr[d] != q_di[d]) return false;
+        if (k_cg[d] < win_start_global[d] || k_cg[d] >= win_end_global[d]) return false;
+    }
+    return true;
+}
+
+// Fast neighbor check: precomputed K coords + precomputed Q window bounds from shared mem.
+// No coordinate decomposition at all — just dilation modulus + range checks.
+static inline bool check_na_window_kq_precomputed(
+    int na_dim, constant int* dilation_arr,
+    thread int* k_cg, threadgroup int* q_di, threadgroup int* win_start_global, threadgroup int* win_end_global
+) {
+    for (int d = 0; d < na_dim; d++) {
+        if (k_cg[d] % dilation_arr[d] != q_di[d]) return false;
+        if (k_cg[d] < win_start_global[d] || k_cg[d] >= win_end_global[d]) return false;
+    }
+    return true;
+}
+
+// Compute KV bounds for a Q position (forward direction)
+static inline void compute_kv_bounds(
+    int q_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal,
+    thread int& min_kv, thread int& max_kv
+) {
+    int q_cg[3] = {0,0,0};
+    { int rem = q_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; q_cg[d] = rem / s; rem = rem % s; } }
+    int kv_sc[3] = {0,0,0}, kv_ec[3] = {0,0,0};
+    for (int d = 0; d < na_dim; d++) {
+        int q_di = q_cg[d] % dilation_arr[d], q_c = q_cg[d] / dilation_arr[d];
+        int eff = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], q_di);
+        int wl = window_size[d] / 2, wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+        int ws, we;
+        if (is_causal[d]) { ws = get_win_start_causal(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_causal(q_c, eff); }
+        else { ws = get_win_start_nc(q_c, wl, wr, stride_arr[d], eff); we = get_win_end_nc(ws, window_size[d]); }
+        kv_sc[d] = ws * dilation_arr[d] + q_di;
+        kv_ec[d] = min((we - 1) * dilation_arr[d] + q_di + 1, qkv_shape[d]);
+    }
+    min_kv = 0; max_kv = 0;
+    for (int d = 0; d < na_dim; d++) {
+        int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i];
+        min_kv += kv_sc[d] * s;
+        max_kv += (kv_ec[d] - 1) * s;
+    }
+    max_kv += 1;
+}
+
+// Compute Q bounds for a K position (reverse direction for dKdV)
+// Conservative: returns the range of Q positions whose window could include k_idx
+static inline void compute_q_bounds_for_k(
+    int k_idx, int na_dim,
+    constant int* qkv_shape, constant int* window_size,
+    constant int* stride_arr, constant int* dilation_arr, constant int* is_causal,
+    int seqlen_q,
+    thread int& min_q, thread int& max_q
+) {
+    int k_cg[3] = {0,0,0};
+    { int rem = k_idx; for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i]; k_cg[d] = rem / s; rem = rem % s; } }
+    int q_sc[3] = {0,0,0}, q_ec[3] = {0,0,0};
+    for (int d = 0; d < na_dim; d++) {
+        int k_di = k_cg[d] % dilation_arr[d];
+        int k_c = k_cg[d] / dilation_arr[d];
+        int wl = window_size[d] / 2;
+        // Conservative Q range in dilated coords
+        if (is_causal[d]) {
+            // Causal: Q at position q can see K at k if k <= q, within window
+            // So Q range is [k_c, k_c + wl + wr] clamped
+            int wr = (window_size[d] / 2) + ((window_size[d] % 2) - 1);
+            int q_min_c = k_c;
+            int eff = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], k_di);
+            int q_max_c = min(k_c + wl + wr, eff - 1);
+            q_sc[d] = q_min_c * dilation_arr[d] + k_di;
+            q_ec[d] = min(q_max_c * dilation_arr[d] + k_di + 1, qkv_shape[d]);
+        } else {
+            // Non-causal: NA boundary correction shifts windows, so Q positions
+            // near edges can see K positions further than wl away.
+            // Use full (window_size - 1) to be conservative.
+            int eff = qkv_fix_dilation(qkv_shape[d], dilation_arr[d], k_di);
+            int q_min_c = max(0, k_c - (window_size[d] - 1));
+            int q_max_c = min(eff - 1, k_c + (window_size[d] - 1));
+            q_sc[d] = q_min_c * dilation_arr[d] + k_di;
+            q_ec[d] = min(q_max_c * dilation_arr[d] + k_di + 1, qkv_shape[d]);
+        }
+    }
+    min_q = 0; max_q = 0;
+    for (int d = 0; d < na_dim; d++) {
+        int s = 1; for (int i = d+1; i < na_dim; i++) s *= qkv_shape[i];
+        min_q += q_sc[d] * s;
+        max_q += (q_ec[d] - 1) * s;
+    }
+    max_q += 1;
+    min_q = max(0, min_q);
+    max_q = min(seqlen_q, max_q);
+}
+
+// =============================================================================
+// Tiled dQ — Q rows fixed in registers, iterate KV tiles in smem
+// =============================================================================
+
+#define TILED_DQ_KERNEL(FNAME, DTYPE, BR, MAX_D) \
+kernel void FNAME( \
+    device const DTYPE* Q       [[buffer(0)]], \
+    device const DTYPE* K       [[buffer(1)]], \
+    device const DTYPE* V       [[buffer(2)]], \
+    device const DTYPE* dO      [[buffer(3)]], \
+    device const float* LSE     [[buffer(4)]], \
+    device const DTYPE* O       [[buffer(5)]], \
+    device DTYPE* dQ            [[buffer(6)]], \
+    constant NAParams& params   [[buffer(7)]], \
+    uint2 tgid                  [[threadgroup_position_in_grid]], \
+    uint tid                    [[thread_index_in_threadgroup]], \
+    uint simd_lane              [[thread_index_in_simdgroup]], \
+    uint simdgroup_id           [[simdgroup_index_in_threadgroup]] \
+) { \
+    constexpr int Br = BR; \
+    constexpr int Bc = 32; \
+    constexpr int ROWS_PER_SIMD = Br / NUM_SIMDGROUPS; \
+    \
+    int tile_q_start = (int)tgid.x * Br; \
+    int idx_L = (int)tgid.y; \
+    if (idx_L >= params.heads_q * params.batch_size) return; \
+    \
+    int batch_idx = idx_L / params.heads_q; \
+    int head_q_idx = idx_L % params.heads_q; \
+    int head_kv_idx = head_q_idx / (params.heads_q / params.heads_kv); \
+    int SQ = params.seqlen_q, SK = params.seqlen_kv; \
+    int D = params.dim, DV = params.dim_value; \
+    int H = params.heads_q, HK = params.heads_kv, na_dim = params.na_dim; \
+    \
+    threadgroup float smem_K[Bc * MAX_D]; \
+    threadgroup float smem_V[Bc * MAX_D]; \
+    \
+    float q_reg[ROWS_PER_SIMD][MAX_D]; \
+    float do_reg[ROWS_PER_SIMD][MAX_D]; \
+    float dq_acc[ROWS_PER_SIMD][MAX_D]; \
+    float row_lse[ROWS_PER_SIMD]; \
+    float row_di[ROWS_PER_SIMD]; \
+    int q_indices[ROWS_PER_SIMD]; \
+    int row_q_di[ROWS_PER_SIMD][3]; \
+    int row_win_start[ROWS_PER_SIMD][3]; \
+    int row_win_end[ROWS_PER_SIMD][3]; \
+    \
+    for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+        int q_row = tile_q_start + (int)simdgroup_id * ROWS_PER_SIMD + r; \
+        q_indices[r] = q_row; \
+        for (int dd = 0; dd < MAX_D; dd++) { q_reg[r][dd] = 0.0f; do_reg[r][dd] = 0.0f; dq_acc[r][dd] = 0.0f; } \
+        row_lse[r] = 0.0f; row_di[r] = 0.0f; \
+        for (int dd = 0; dd < 3; dd++) { row_q_di[r][dd] = 0; row_win_start[r][dd] = 0; row_win_end[r][dd] = 0; } \
+        if (q_row < SQ) { \
+            int q_base = batch_idx * SQ * H * D + q_row * H * D + head_q_idx * D; \
+            int do_base = batch_idx * SQ * H * DV + q_row * H * DV + head_q_idx * DV; \
+            for (int dd = 0; dd < D; dd++) q_reg[r][dd] = float(Q[q_base + dd]); \
+            for (int dd = 0; dd < DV; dd++) do_reg[r][dd] = float(dO[do_base + dd]); \
+            int lse_idx = batch_idx * SQ * H + q_row * H + head_q_idx; \
+            row_lse[r] = LSE[lse_idx]; \
+            /* Compute Di = dot(dO, O) * attn_scale inline */ \
+            { float di_acc = 0.0f; \
+              int o_base = batch_idx * SQ * H * DV + q_row * H * DV + head_q_idx * DV; \
+              for (int dd = 0; dd < DV; dd++) di_acc += do_reg[r][dd] * float(O[o_base + dd]); \
+              row_di[r] = di_acc * params.attn_scale; } \
+            precompute_q_window(q_row, na_dim, params.qkv_shape, params.window_size, \
+                                params.stride, params.dilation, params.is_causal, \
+                                row_q_di[r], row_win_start[r], row_win_end[r]); \
+        } \
+    } \
+    \
+    /* KV Bounding Box — as_type bit-cast through smem_K (no extra threadgroup memory) */ \
+    int first_tile, last_tile; \
+    { \
+        int local_min_kv = SK, local_max_kv = 0; \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            if (q_indices[r] < SQ) { \
+                int qmin, qmax; \
+                compute_kv_bounds(q_indices[r], na_dim, params.qkv_shape, params.window_size, \
+                                  params.stride, params.dilation, params.is_causal, qmin, qmax); \
+                local_min_kv = min(local_min_kv, qmin); local_max_kv = max(local_max_kv, qmax); \
+            } \
+        } \
+        int sg_mn = simd_min(local_min_kv), sg_mx = simd_max(local_max_kv); \
+        if (simd_lane == 0) { \
+            smem_K[simdgroup_id * 2 + 0] = as_type<float>(sg_mn); \
+            smem_K[simdgroup_id * 2 + 1] = as_type<float>(sg_mx); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        int bbox_min_kv, bbox_max_kv; \
+        if (tid == 0) { \
+            bbox_min_kv = as_type<int>(smem_K[0]); \
+            bbox_max_kv = as_type<int>(smem_K[1]); \
+            for (int s = 1; s < NUM_SIMDGROUPS; s++) { \
+                bbox_min_kv = min(bbox_min_kv, as_type<int>(smem_K[s * 2])); \
+                bbox_max_kv = max(bbox_max_kv, as_type<int>(smem_K[s * 2 + 1])); \
+            } \
+            smem_K[0] = as_type<float>(bbox_min_kv); \
+            smem_K[1] = as_type<float>(bbox_max_kv); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        bbox_min_kv = as_type<int>(smem_K[0]); \
+        bbox_max_kv = as_type<int>(smem_K[1]); \
+        first_tile = bbox_min_kv / Bc; \
+        last_tile = min((bbox_max_kv + Bc - 1) / Bc, (SK + Bc - 1) / Bc); \
+    } \
+    \
+    /* Main KV Tile Loop */ \
+    for (int tile_idx = first_tile; tile_idx < last_tile; tile_idx++) { \
+        int kv_start = tile_idx * Bc; \
+        int kv_end = min(kv_start + Bc, SK); \
+        int tile_len = kv_end - kv_start; \
+        \
+        /* Cooperative load K tile */ \
+        int total_k = tile_len * D; \
+        for (int i = (int)tid; i < total_k; i += NUM_THREADS) { \
+            int kk = i / D, dd = i % D; \
+            smem_K[kk*D+dd] = float(K[batch_idx*SK*HK*D + (kv_start+kk)*HK*D + head_kv_idx*D + dd]); \
+        } \
+        /* Cooperative load V tile */ \
+        int total_v = tile_len * DV; \
+        for (int i = (int)tid; i < total_v; i += NUM_THREADS) { \
+            int kk = i / DV, dd = i % DV; \
+            smem_V[kk*DV+dd] = float(V[batch_idx*SK*HK*DV + (kv_start+kk)*HK*DV + head_kv_idx*DV + dd]); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int q_row = q_indices[r]; \
+            if (q_row >= SQ) continue; \
+            \
+            int k_pos = (int)simd_lane; \
+            float score = -INFINITY; \
+            float dov_val = 0.0f; \
+            if (k_pos < tile_len) { \
+                int global_k = kv_start + k_pos; \
+                /* Q*K dot product */ \
+                float acc = 0.0f; \
+                for (int dd = 0; dd < D; dd += 4) { \
+                    int rem = min(4, D - dd); \
+                    if (rem == 4) { \
+                        float4 q4 = float4(q_reg[r][dd], q_reg[r][dd+1], q_reg[r][dd+2], q_reg[r][dd+3]); \
+                        float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                        acc += dot(q4, k4); \
+                    } else { for (int ddd = 0; ddd < rem; ddd++) acc += q_reg[r][dd+ddd] * smem_K[k_pos*D+dd+ddd]; } \
+                } \
+                acc *= params.attn_scale; \
+                /* NA mask (uses precomputed Q window bounds) */ \
+                bool is_nb = check_na_window(global_k, na_dim, params.qkv_shape, params.dilation, row_q_di[r], row_win_start[r], row_win_end[r]); \
+                score = is_nb ? acc : -INFINITY; \
+                /* dO*V dot product */ \
+                for (int dd = 0; dd < DV; dd += 4) { \
+                    int rem = min(4, DV - dd); \
+                    if (rem == 4) { \
+                        float4 do4 = float4(do_reg[r][dd], do_reg[r][dd+1], do_reg[r][dd+2], do_reg[r][dd+3]); \
+                        float4 v4 = *reinterpret_cast<threadgroup const float4*>(&smem_V[k_pos*DV+dd]); \
+                        dov_val += dot(do4, v4); \
+                    } else { for (int ddd = 0; ddd < rem; ddd++) dov_val += do_reg[r][dd+ddd] * smem_V[k_pos*DV+dd+ddd]; } \
+                } \
+                dov_val *= params.attn_scale; \
+            } \
+            \
+            /* P = exp(score - LSE), dS = P * (dO*V*scale - Di) */ \
+            float P = (score != -INFINITY) ? exp(min(score - row_lse[r], 0.0f)) : 0.0f; \
+            float dS = P * (dov_val - row_di[r]); \
+            \
+            /* dQ accumulation: dQ[d] += simd_sum(dS * K[lane][d]) */ \
+            if (k_pos < tile_len) { \
+                for (int dd = 0; dd < D; dd += 4) { \
+                    int rem = min(4, D - dd); \
+                    if (rem == 4) { \
+                        float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                        dq_acc[r][dd]   += simd_sum(dS * k4.x); \
+                        dq_acc[r][dd+1] += simd_sum(dS * k4.y); \
+                        dq_acc[r][dd+2] += simd_sum(dS * k4.z); \
+                        dq_acc[r][dd+3] += simd_sum(dS * k4.w); \
+                    } else { for (int ddd = 0; ddd < rem; ddd++) dq_acc[r][dd+ddd] += simd_sum(dS * smem_K[k_pos*D+dd+ddd]); } \
+                } \
+            } else { \
+                for (int dd = 0; dd < D; dd += 4) { int rem = min(4, D - dd); if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } } \
+            } \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+    } \
+    \
+    /* Additional KV tile loop */ \
+    if (params.num_additional_kv > 0) { \
+        int add_first = SQ / Bc; \
+        int add_last = (SQ + params.num_additional_kv + Bc - 1) / Bc; \
+        add_last = min(add_last, (SK + Bc - 1) / Bc); \
+        for (int tile_idx = add_first; tile_idx < add_last; tile_idx++) { \
+            if (tile_idx >= first_tile && tile_idx < last_tile) continue; \
+            int kv_start = tile_idx * Bc; \
+            int kv_end = min(kv_start + Bc, SK); \
+            int tile_len = kv_end - kv_start; \
+            int total_k = tile_len * D; \
+            for (int i = (int)tid; i < total_k; i += NUM_THREADS) { \
+                int kk = i / D, dd = i % D; \
+                smem_K[kk*D+dd] = float(K[batch_idx*SK*HK*D + (kv_start+kk)*HK*D + head_kv_idx*D + dd]); \
+            } \
+            int total_v = tile_len * DV; \
+            for (int i = (int)tid; i < total_v; i += NUM_THREADS) { \
+                int kk = i / DV, dd = i % DV; \
+                smem_V[kk*DV+dd] = float(V[batch_idx*SK*HK*DV + (kv_start+kk)*HK*DV + head_kv_idx*DV + dd]); \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+            for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+                int q_row = q_indices[r]; \
+                if (q_row >= SQ) continue; \
+                int k_pos = (int)simd_lane; \
+                float score = -INFINITY; \
+                float dov_val = 0.0f; \
+                if (k_pos < tile_len) { \
+                    int global_k = kv_start + k_pos; \
+                    if (global_k >= SQ && global_k - SQ < params.num_additional_kv) { \
+                        float acc = 0.0f; \
+                        for (int dd = 0; dd < D; dd += 4) { \
+                            int rem = min(4, D - dd); \
+                            if (rem == 4) { \
+                                float4 q4 = float4(q_reg[r][dd], q_reg[r][dd+1], q_reg[r][dd+2], q_reg[r][dd+3]); \
+                                float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                                acc += dot(q4, k4); \
+                            } else { for (int ddd = 0; ddd < rem; ddd++) acc += q_reg[r][dd+ddd] * smem_K[k_pos*D+dd+ddd]; } \
+                        } \
+                        score = acc * params.attn_scale; \
+                        for (int dd = 0; dd < DV; dd += 4) { \
+                            int rem = min(4, DV - dd); \
+                            if (rem == 4) { \
+                                float4 do4 = float4(do_reg[r][dd], do_reg[r][dd+1], do_reg[r][dd+2], do_reg[r][dd+3]); \
+                                float4 v4 = *reinterpret_cast<threadgroup const float4*>(&smem_V[k_pos*DV+dd]); \
+                                dov_val += dot(do4, v4); \
+                            } else { for (int ddd = 0; ddd < rem; ddd++) dov_val += do_reg[r][dd+ddd] * smem_V[k_pos*DV+dd+ddd]; } \
+                        } \
+                        dov_val *= params.attn_scale; \
+                    } \
+                } \
+                float P = (score != -INFINITY) ? exp(min(score - row_lse[r], 0.0f)) : 0.0f; \
+                float dS = P * (dov_val - row_di[r]); \
+                if (k_pos < tile_len) { \
+                    for (int dd = 0; dd < D; dd += 4) { \
+                        int rem = min(4, D - dd); \
+                        if (rem == 4) { \
+                            float4 k4 = *reinterpret_cast<threadgroup const float4*>(&smem_K[k_pos*D+dd]); \
+                            dq_acc[r][dd]   += simd_sum(dS * k4.x); \
+                            dq_acc[r][dd+1] += simd_sum(dS * k4.y); \
+                            dq_acc[r][dd+2] += simd_sum(dS * k4.z); \
+                            dq_acc[r][dd+3] += simd_sum(dS * k4.w); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) dq_acc[r][dd+ddd] += simd_sum(dS * smem_K[k_pos*D+dd+ddd]); } \
+                    } \
+                } else { \
+                    for (int dd = 0; dd < D; dd += 4) { int rem = min(4, D - dd); if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } } \
+                } \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+        } \
+    } \
+    \
+    /* Write dQ */ \
+    if (simd_lane == 0) { \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int q_row = q_indices[r]; \
+            if (q_row >= SQ) continue; \
+            int dq_base = batch_idx * SQ * H * D + q_row * H * D + head_q_idx * D; \
+            for (int dd = 0; dd < D; dd++) dQ[dq_base + dd] = DTYPE(dq_acc[r][dd]); \
+        } \
+    } \
+}
+
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp32_br32_d32, float, 32, 32)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp32_br32, float, 32, 64)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp32_br16, float, 16, 128)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp16_br32_d32, half, 32, 32)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp16_br32, half, 32, 64)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_fp16_br16, half, 16, 128)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_bf16_br32_d32, bfloat, 32, 32)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_bf16_br32, bfloat, 32, 64)
+TILED_DQ_KERNEL(na_backward_tiled_dQ_bf16_br16, bfloat, 16, 128)
+
+// =============================================================================
+// Kernel 3: Fused Tiled dKdV — K/V rows fixed in registers, iterate Q tiles
+// =============================================================================
+
+#define TILED_DKDV_KERNEL(FNAME, DTYPE, BR, BC, MAX_D) \
+kernel void FNAME( \
+    device const DTYPE* Q       [[buffer(0)]], \
+    device const DTYPE* K       [[buffer(1)]], \
+    device const DTYPE* V       [[buffer(2)]], \
+    device const DTYPE* dO      [[buffer(3)]], \
+    device const float* LSE     [[buffer(4)]], \
+    device const DTYPE* O       [[buffer(5)]], \
+    device DTYPE* dK            [[buffer(6)]], \
+    device DTYPE* dV            [[buffer(7)]], \
+    constant NAParams& params   [[buffer(8)]], \
+    uint2 tgid                  [[threadgroup_position_in_grid]], \
+    uint tid                    [[thread_index_in_threadgroup]], \
+    uint simd_lane              [[thread_index_in_simdgroup]], \
+    uint simdgroup_id           [[simdgroup_index_in_threadgroup]] \
+) { \
+    constexpr int Br = BR; \
+    constexpr int Bc = BC; \
+    constexpr int ROWS_PER_SIMD = Br / NUM_SIMDGROUPS; \
+    \
+    int tile_kv_start = (int)tgid.x * Br; \
+    int idx_L = (int)tgid.y; \
+    if (idx_L >= params.heads_kv * params.batch_size) return; \
+    \
+    int batch_idx = idx_L / params.heads_kv; \
+    int head_kv_idx = idx_L % params.heads_kv; \
+    int gqa_ratio = params.heads_q / params.heads_kv; \
+    int SQ = params.seqlen_q, SK = params.seqlen_kv; \
+    int D = params.dim, DV = params.dim_value; \
+    int H = params.heads_q, HK = params.heads_kv, na_dim = params.na_dim; \
+    \
+    /* Shared memory for Q tile + dO tile + LSE/Di + precomputed Q window bounds */ \
+    threadgroup float smem_Q[Bc * MAX_D]; \
+    threadgroup float smem_dO[Bc * MAX_D]; \
+    threadgroup float smem_LSE[Bc]; \
+    threadgroup float smem_Di[Bc]; \
+    threadgroup int smem_q_di[Bc * 3]; \
+    threadgroup int smem_win_start[Bc * 3]; \
+    threadgroup int smem_win_end[Bc * 3]; \
+    \
+    /* Load K and V rows into registers */ \
+    float k_reg[ROWS_PER_SIMD][MAX_D]; \
+    float v_reg[ROWS_PER_SIMD][MAX_D]; \
+    float dk_acc[ROWS_PER_SIMD][MAX_D]; \
+    float dv_acc[ROWS_PER_SIMD][MAX_D]; \
+    int kv_indices[ROWS_PER_SIMD]; \
+    int kv_coords[ROWS_PER_SIMD][3]; \
+    bool kv_is_additional[ROWS_PER_SIMD]; \
+    \
+    for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+        int kv_row = tile_kv_start + (int)simdgroup_id * ROWS_PER_SIMD + r; \
+        kv_indices[r] = kv_row; \
+        kv_coords[r][0] = 0; kv_coords[r][1] = 0; kv_coords[r][2] = 0; \
+        kv_is_additional[r] = (kv_row >= SQ && kv_row < SK); \
+        for (int dd = 0; dd < MAX_D; dd++) { k_reg[r][dd] = 0.0f; v_reg[r][dd] = 0.0f; dk_acc[r][dd] = 0.0f; dv_acc[r][dd] = 0.0f; } \
+        if (kv_row < SK) { \
+            int k_base = batch_idx * SK * HK * D + kv_row * HK * D + head_kv_idx * D; \
+            int v_base = batch_idx * SK * HK * DV + kv_row * HK * DV + head_kv_idx * DV; \
+            for (int dd = 0; dd < D; dd++) k_reg[r][dd] = float(K[k_base + dd]); \
+            for (int dd = 0; dd < DV; dd++) v_reg[r][dd] = float(V[v_base + dd]); \
+            /* Precompute K coords for fast NA mask check */ \
+            if (!kv_is_additional[r]) { \
+                int rem = kv_row; \
+                for (int d = 0; d < na_dim; d++) { int s = 1; for (int i = d+1; i < na_dim; i++) s *= params.qkv_shape[i]; kv_coords[r][d] = rem / s; rem = rem % s; } \
+            } \
+        } \
+    } \
+    \
+    /* Reverse Q bounding box — as_type bit-cast through smem_Q (no extra threadgroup memory) */ \
+    int first_tile, last_tile; \
+    { \
+        int local_min_q = SQ, local_max_q = 0; \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            if (kv_indices[r] < SK) { \
+                int kv_row = kv_indices[r]; \
+                if (kv_row >= SQ && kv_row - SQ < params.num_additional_kv) { \
+                    local_min_q = 0; local_max_q = SQ; \
+                } else if (kv_row < SQ) { \
+                    int qmin, qmax; \
+                    compute_q_bounds_for_k(kv_row, na_dim, params.qkv_shape, params.window_size, \
+                                           params.stride, params.dilation, params.is_causal, SQ, qmin, qmax); \
+                    local_min_q = min(local_min_q, qmin); local_max_q = max(local_max_q, qmax); \
+                } \
+            } \
+        } \
+        int sg_mn = simd_min(local_min_q), sg_mx = simd_max(local_max_q); \
+        if (simd_lane == 0) { \
+            smem_Q[simdgroup_id * 2 + 0] = as_type<float>(sg_mn); \
+            smem_Q[simdgroup_id * 2 + 1] = as_type<float>(sg_mx); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        int bbox_min_q, bbox_max_q; \
+        if (tid == 0) { \
+            bbox_min_q = as_type<int>(smem_Q[0]); \
+            bbox_max_q = as_type<int>(smem_Q[1]); \
+            for (int s = 1; s < NUM_SIMDGROUPS; s++) { \
+                bbox_min_q = min(bbox_min_q, as_type<int>(smem_Q[s * 2])); \
+                bbox_max_q = max(bbox_max_q, as_type<int>(smem_Q[s * 2 + 1])); \
+            } \
+            smem_Q[0] = as_type<float>(bbox_min_q); \
+            smem_Q[1] = as_type<float>(bbox_max_q); \
+        } \
+        threadgroup_barrier(mem_flags::mem_threadgroup); \
+        bbox_min_q = as_type<int>(smem_Q[0]); \
+        bbox_max_q = as_type<int>(smem_Q[1]); \
+        first_tile = bbox_min_q / Bc; \
+        last_tile = min((bbox_max_q + Bc - 1) / Bc, (SQ + Bc - 1) / Bc); \
+    } \
+    \
+    /* GQA loop over Q heads mapping to this KV head */ \
+    for (int gqa = 0; gqa < gqa_ratio; gqa++) { \
+        int head_q_idx = head_kv_idx * gqa_ratio + gqa; \
+        \
+        /* Q Tile Loop */ \
+        for (int tile_idx = first_tile; tile_idx < last_tile; tile_idx++) { \
+            int q_start = tile_idx * Bc; \
+            int q_end = min(q_start + Bc, SQ); \
+            int tile_len = q_end - q_start; \
+            \
+            /* Cooperative load Q + dO + LSE + Di */ \
+            int total_q = tile_len * D; \
+            for (int i = (int)tid; i < total_q; i += NUM_THREADS) { \
+                int qq = i / D, dd = i % D; \
+                smem_Q[qq*D+dd] = float(Q[batch_idx*SQ*H*D + (q_start+qq)*H*D + head_q_idx*D + dd]); \
+            } \
+            int total_do = tile_len * DV; \
+            for (int i = (int)tid; i < total_do; i += NUM_THREADS) { \
+                int qq = i / DV, dd = i % DV; \
+                smem_dO[qq*DV+dd] = float(dO[batch_idx*SQ*H*DV + (q_start+qq)*H*DV + head_q_idx*DV + dd]); \
+            } \
+            for (int i = (int)tid; i < tile_len; i += NUM_THREADS) { \
+                int lse_idx = batch_idx * SQ * H + (q_start+i) * H + head_q_idx; \
+                smem_LSE[i] = LSE[lse_idx]; \
+                /* Compute Di = dot(dO, O) * attn_scale inline */ \
+                int o_base = batch_idx * SQ * H * DV + (q_start+i) * H * DV + head_q_idx * DV; \
+                float di_acc = 0.0f; \
+                for (int dd = 0; dd < DV; dd++) di_acc += float(dO[o_base + dd]) * float(O[o_base + dd]); \
+                smem_Di[i] = di_acc * params.attn_scale; \
+            } \
+            /* Cooperatively precompute Q window bounds for this tile */ \
+            for (int i = (int)tid; i < tile_len; i += NUM_THREADS) { \
+                int global_q = q_start + i; \
+                int tmp_di[3], tmp_ws[3], tmp_we[3]; \
+                precompute_q_window(global_q, na_dim, params.qkv_shape, params.window_size, \
+                                    params.stride, params.dilation, params.is_causal, \
+                                    tmp_di, tmp_ws, tmp_we); \
+                for (int d = 0; d < 3; d++) { \
+                    smem_q_di[i*3+d] = tmp_di[d]; \
+                    smem_win_start[i*3+d] = tmp_ws[d]; \
+                    smem_win_end[i*3+d] = tmp_we[d]; \
+                } \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+            \
+            for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+                int kv_row = kv_indices[r]; \
+                if (kv_row >= SK) continue; \
+                \
+                int q_pos = (int)simd_lane; \
+                float score = -INFINITY; \
+                float dov_val = 0.0f; \
+                float q_lse = 0.0f, q_di = 0.0f; \
+                if (q_pos < tile_len) { \
+                    int global_q = q_start + q_pos; \
+                    /* Q*K dot */ \
+                    float acc = 0.0f; \
+                    for (int dd = 0; dd < D; dd += 4) { \
+                        int rem = min(4, D - dd); \
+                        if (rem == 4) { \
+                            float4 q4 = *reinterpret_cast<threadgroup const float4*>(&smem_Q[q_pos*D+dd]); \
+                            float4 k4 = float4(k_reg[r][dd], k_reg[r][dd+1], k_reg[r][dd+2], k_reg[r][dd+3]); \
+                            acc += dot(q4, k4); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) acc += smem_Q[q_pos*D+dd+ddd] * k_reg[r][dd+ddd]; } \
+                    } \
+                    acc *= params.attn_scale; \
+                    /* NA mask: precomputed K coords (registers) + precomputed Q window (shared mem) */ \
+                    bool is_nb; \
+                    if (kv_is_additional[r]) { is_nb = true; } \
+                    else { \
+                        is_nb = check_na_window_kq_precomputed(na_dim, params.dilation, \
+                            kv_coords[r], &smem_q_di[q_pos*3], &smem_win_start[q_pos*3], &smem_win_end[q_pos*3]); \
+                    } \
+                    score = is_nb ? acc : -INFINITY; \
+                    q_lse = smem_LSE[q_pos]; \
+                    q_di = smem_Di[q_pos]; \
+                    /* dO*V dot */ \
+                    for (int dd = 0; dd < DV; dd += 4) { \
+                        int rem = min(4, DV - dd); \
+                        if (rem == 4) { \
+                            float4 do4 = *reinterpret_cast<threadgroup const float4*>(&smem_dO[q_pos*DV+dd]); \
+                            float4 v4 = float4(v_reg[r][dd], v_reg[r][dd+1], v_reg[r][dd+2], v_reg[r][dd+3]); \
+                            dov_val += dot(do4, v4); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) dov_val += smem_dO[q_pos*DV+dd+ddd] * v_reg[r][dd+ddd]; } \
+                    } \
+                    dov_val *= params.attn_scale; \
+                } \
+                \
+                float P = (score != -INFINITY) ? exp(min(score - q_lse, 0.0f)) : 0.0f; \
+                float dS = P * (dov_val - q_di); \
+                \
+                /* dK accumulation */ \
+                if (q_pos < tile_len) { \
+                    for (int dd = 0; dd < D; dd += 4) { \
+                        int rem = min(4, D - dd); \
+                        if (rem == 4) { \
+                            float4 q4 = *reinterpret_cast<threadgroup const float4*>(&smem_Q[q_pos*D+dd]); \
+                            dk_acc[r][dd]   += simd_sum(dS * q4.x); \
+                            dk_acc[r][dd+1] += simd_sum(dS * q4.y); \
+                            dk_acc[r][dd+2] += simd_sum(dS * q4.z); \
+                            dk_acc[r][dd+3] += simd_sum(dS * q4.w); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) dk_acc[r][dd+ddd] += simd_sum(dS * smem_Q[q_pos*D+dd+ddd]); } \
+                    } \
+                } else { \
+                    for (int dd = 0; dd < D; dd += 4) { int rem = min(4, D - dd); if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } } \
+                } \
+                /* dV accumulation */ \
+                if (q_pos < tile_len) { \
+                    for (int dd = 0; dd < DV; dd += 4) { \
+                        int rem = min(4, DV - dd); \
+                        if (rem == 4) { \
+                            float4 do4 = *reinterpret_cast<threadgroup const float4*>(&smem_dO[q_pos*DV+dd]); \
+                            dv_acc[r][dd]   += simd_sum(P * do4.x); \
+                            dv_acc[r][dd+1] += simd_sum(P * do4.y); \
+                            dv_acc[r][dd+2] += simd_sum(P * do4.z); \
+                            dv_acc[r][dd+3] += simd_sum(P * do4.w); \
+                        } else { for (int ddd = 0; ddd < rem; ddd++) dv_acc[r][dd+ddd] += simd_sum(P * smem_dO[q_pos*DV+dd+ddd]); } \
+                    } \
+                } else { \
+                    for (int dd = 0; dd < DV; dd += 4) { int rem = min(4, DV - dd); if (rem == 4) { simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); simd_sum(0.0f); } else { for (int ddd = 0; ddd < rem; ddd++) simd_sum(0.0f); } } \
+                } \
+            } \
+            threadgroup_barrier(mem_flags::mem_threadgroup); \
+        } \
+    } \
+    \
+    /* Write dK and dV */ \
+    if (simd_lane == 0) { \
+        for (int r = 0; r < ROWS_PER_SIMD; r++) { \
+            int kv_row = kv_indices[r]; \
+            if (kv_row >= SK) continue; \
+            int dk_base = batch_idx * SK * HK * D + kv_row * HK * D + head_kv_idx * D; \
+            int dv_base = batch_idx * SK * HK * DV + kv_row * HK * DV + head_kv_idx * DV; \
+            for (int dd = 0; dd < D; dd++) dK[dk_base + dd] = DTYPE(dk_acc[r][dd]); \
+            for (int dd = 0; dd < DV; dd++) dV[dv_base + dd] = DTYPE(dv_acc[r][dd]); \
+        } \
+    } \
+}
+
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp32_br32_d32, float, 32, 32, 32)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp32_br32, float, 32, 32, 64)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp32_br16, float, 16, 16, 128)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp16_br32_d32, half, 32, 32, 32)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp16_br32, half, 32, 32, 64)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_fp16_br16, half, 16, 16, 128)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_bf16_br32_d32, bfloat, 32, 32, 32)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_bf16_br32, bfloat, 32, 32, 64)
+TILED_DKDV_KERNEL(na_backward_tiled_dKdV_bf16_br16, bfloat, 16, 16, 128)
+
+)";
+}
+
+// =============================================================================
+// Metal Kernel Cache (Thread-Safe)
+// =============================================================================
+
+static std::mutex g_init_mutex;
+static std::atomic<bool> g_initialized{false};
+
+static id<MTLDevice> g_device = nil;
+static id<MTLLibrary> g_library = nil;
+static id<MTLLibrary> g_bwd_library = nil;
+static id<MTLLibrary> g_tiled_library = nil;
+static id<MTLLibrary> g_tiled_bwd_library = nil;
+static id<MTLComputePipelineState> g_na_fwd_fp32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_fp16 = nil;
+static id<MTLComputePipelineState> g_na_fwd_bf16 = nil;
+// Tiled forward pipelines (flash-attention style)
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp32_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp32_br32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp32_br16 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp16_br32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_fp16_br16 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_bf16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_bf16_br32 = nil;
+static id<MTLComputePipelineState> g_na_fwd_tiled_bf16_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dQ_fp32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dQ_fp16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dQ_bf16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dK_fp32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dK_fp16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dK_bf16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dV_fp32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dV_fp16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_dV_bf16 = nil;
+// Tiled backward pipelines (Di fused into dQ/dKdV, no separate Di kernel)
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp32_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp32_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp32_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp16_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_fp16_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_bf16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_bf16_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dQ_bf16_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp32_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp32_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp32_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp16_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_fp16_br16 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_bf16_br32_d32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_bf16_br32 = nil;
+static id<MTLComputePipelineState> g_na_bwd_tiled_dKdV_bf16_br16 = nil;
+
+static bool init_metal() {
+    if (g_initialized.load(std::memory_order_acquire)) {
+        return true;
+    }
+
+    std::lock_guard<std::mutex> lock(g_init_mutex);
+
+    if (g_initialized.load(std::memory_order_relaxed)) {
+        return true;
+    }
+
+    @autoreleasepool {
+        g_device = MTLCreateSystemDefaultDevice();
+        TORCH_CHECK(g_device, "Failed to create Metal device");
+
+        NSError* error = nil;
+        MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+        options.mathMode = MTLMathModeFast;
+
+        g_library = [g_device newLibraryWithSource:get_metal_source() options:options error:&error];
+        TORCH_CHECK(g_library, "Failed to compile Metal library: ",
+                     error ? [[error localizedDescription] UTF8String] : "unknown");
+
+        auto create_pipeline = [&](NSString* name) -> id<MTLComputePipelineState> {
+            id<MTLFunction> fn = [g_library newFunctionWithName:name];
+            TORCH_CHECK(fn, "Failed to find Metal function: ", [name UTF8String]);
+            id<MTLComputePipelineState> pipeline =
+                [g_device newComputePipelineStateWithFunction:fn error:&error];
+            TORCH_CHECK(pipeline, "Failed to create pipeline for ", [name UTF8String], ": ",
+                         error ? [[error localizedDescription] UTF8String] : "unknown");
+            return pipeline;
+        };
+
+        g_na_fwd_fp32 = create_pipeline(@"na_forward_fp32");
+        g_na_fwd_fp16 = create_pipeline(@"na_forward_fp16");
+
+        @try {
+            g_na_fwd_bf16 = create_pipeline(@"na_forward_bf16");
+        } @catch (NSException *exception) {
+            g_na_fwd_bf16 = nil;
+        }
+
+        // Compile tiled forward kernels
+        NSError* tiled_error = nil;
+        g_tiled_library = [g_device newLibraryWithSource:get_metal_tiled_source() options:options error:&tiled_error];
+        TORCH_CHECK(g_tiled_library, "Failed to compile Metal tiled library: ",
+                     tiled_error ? [[tiled_error localizedDescription] UTF8String] : "unknown");
+
+        auto create_tiled_pipeline = [&](NSString* name) -> id<MTLComputePipelineState> {
+            id<MTLFunction> fn = [g_tiled_library newFunctionWithName:name];
+            TORCH_CHECK(fn, "Failed to find Metal tiled function: ", [name UTF8String]);
+            NSError* err = nil;
+            id<MTLComputePipelineState> pipeline =
+                [g_device newComputePipelineStateWithFunction:fn error:&err];
+            TORCH_CHECK(pipeline, "Failed to create tiled pipeline for ", [name UTF8String], ": ",
+                         err ? [[err localizedDescription] UTF8String] : "unknown");
+            return pipeline;
+        };
+
+        g_na_fwd_tiled_fp32_br32_d32 = create_tiled_pipeline(@"na_forward_tiled_fp32_br32_d32");
+        g_na_fwd_tiled_fp32_br32 = create_tiled_pipeline(@"na_forward_tiled_fp32_br32");
+        g_na_fwd_tiled_fp32_br16 = create_tiled_pipeline(@"na_forward_tiled_fp32_br16");
+        g_na_fwd_tiled_fp16_br32_d32 = create_tiled_pipeline(@"na_forward_tiled_fp16_br32_d32");
+        g_na_fwd_tiled_fp16_br32 = create_tiled_pipeline(@"na_forward_tiled_fp16_br32");
+        g_na_fwd_tiled_fp16_br16 = create_tiled_pipeline(@"na_forward_tiled_fp16_br16");
+
+        @try {
+            g_na_fwd_tiled_bf16_br32_d32 = create_tiled_pipeline(@"na_forward_tiled_bf16_br32_d32");
+            g_na_fwd_tiled_bf16_br32 = create_tiled_pipeline(@"na_forward_tiled_bf16_br32");
+            g_na_fwd_tiled_bf16_br16 = create_tiled_pipeline(@"na_forward_tiled_bf16_br16");
+        } @catch (NSException *exception) {
+            g_na_fwd_tiled_bf16_br32_d32 = nil;
+            g_na_fwd_tiled_bf16_br32 = nil;
+            g_na_fwd_tiled_bf16_br16 = nil;
+        }
+
+        // Compile backward kernels
+        NSError* bwd_error = nil;
+        g_bwd_library = [g_device newLibraryWithSource:get_metal_backward_source() options:options error:&bwd_error];
+        TORCH_CHECK(g_bwd_library, "Failed to compile Metal backward library: ",
+                     bwd_error ? [[bwd_error localizedDescription] UTF8String] : "unknown");
+
+        auto create_bwd_pipeline = [&](NSString* name) -> id<MTLComputePipelineState> {
+            id<MTLFunction> fn = [g_bwd_library newFunctionWithName:name];
+            TORCH_CHECK(fn, "Failed to find Metal backward function: ", [name UTF8String]);
+            NSError* err = nil;
+            id<MTLComputePipelineState> pipeline =
+                [g_device newComputePipelineStateWithFunction:fn error:&err];
+            TORCH_CHECK(pipeline, "Failed to create backward pipeline for ", [name UTF8String], ": ",
+                         err ? [[err localizedDescription] UTF8String] : "unknown");
+            return pipeline;
+        };
+
+        g_na_bwd_dQ_fp32 = create_bwd_pipeline(@"na_backward_dQ_fp32");
+        g_na_bwd_dK_fp32 = create_bwd_pipeline(@"na_backward_dK_fp32");
+        g_na_bwd_dV_fp32 = create_bwd_pipeline(@"na_backward_dV_fp32");
+        g_na_bwd_dQ_fp16 = create_bwd_pipeline(@"na_backward_dQ_fp16");
+        g_na_bwd_dK_fp16 = create_bwd_pipeline(@"na_backward_dK_fp16");
+        g_na_bwd_dV_fp16 = create_bwd_pipeline(@"na_backward_dV_fp16");
+
+        @try {
+            g_na_bwd_dQ_bf16 = create_bwd_pipeline(@"na_backward_dQ_bf16");
+            g_na_bwd_dK_bf16 = create_bwd_pipeline(@"na_backward_dK_bf16");
+            g_na_bwd_dV_bf16 = create_bwd_pipeline(@"na_backward_dV_bf16");
+        } @catch (NSException *exception) {
+            g_na_bwd_dQ_bf16 = nil;
+            g_na_bwd_dK_bf16 = nil;
+            g_na_bwd_dV_bf16 = nil;
+        }
+
+        // Compile tiled backward kernels
+        NSError* tiled_bwd_error = nil;
+        g_tiled_bwd_library = [g_device newLibraryWithSource:get_metal_tiled_backward_source() options:options error:&tiled_bwd_error];
+        TORCH_CHECK(g_tiled_bwd_library, "Failed to compile Metal tiled backward library: ",
+                     tiled_bwd_error ? [[tiled_bwd_error localizedDescription] UTF8String] : "unknown");
+
+        auto create_tiled_bwd_pipeline = [&](NSString* name) -> id<MTLComputePipelineState> {
+            id<MTLFunction> fn = [g_tiled_bwd_library newFunctionWithName:name];
+            TORCH_CHECK(fn, "Failed to find Metal tiled backward function: ", [name UTF8String]);
+            NSError* err = nil;
+            id<MTLComputePipelineState> pipeline =
+                [g_device newComputePipelineStateWithFunction:fn error:&err];
+            TORCH_CHECK(pipeline, "Failed to create tiled backward pipeline for ", [name UTF8String], ": ",
+                         err ? [[err localizedDescription] UTF8String] : "unknown");
+            return pipeline;
+        };
+
+        g_na_bwd_tiled_dQ_fp32_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp32_br32_d32");
+        g_na_bwd_tiled_dQ_fp32_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp32_br32");
+        g_na_bwd_tiled_dQ_fp32_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp32_br16");
+        g_na_bwd_tiled_dQ_fp16_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp16_br32_d32");
+        g_na_bwd_tiled_dQ_fp16_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp16_br32");
+        g_na_bwd_tiled_dQ_fp16_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_fp16_br16");
+        g_na_bwd_tiled_dKdV_fp32_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp32_br32_d32");
+        g_na_bwd_tiled_dKdV_fp32_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp32_br32");
+        g_na_bwd_tiled_dKdV_fp32_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp32_br16");
+        g_na_bwd_tiled_dKdV_fp16_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp16_br32_d32");
+        g_na_bwd_tiled_dKdV_fp16_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp16_br32");
+        g_na_bwd_tiled_dKdV_fp16_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_fp16_br16");
+
+        @try {
+            g_na_bwd_tiled_dQ_bf16_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_bf16_br32_d32");
+            g_na_bwd_tiled_dQ_bf16_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_bf16_br32");
+            g_na_bwd_tiled_dQ_bf16_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dQ_bf16_br16");
+            g_na_bwd_tiled_dKdV_bf16_br32_d32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_bf16_br32_d32");
+            g_na_bwd_tiled_dKdV_bf16_br32 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_bf16_br32");
+            g_na_bwd_tiled_dKdV_bf16_br16 = create_tiled_bwd_pipeline(@"na_backward_tiled_dKdV_bf16_br16");
+        } @catch (NSException *exception) {
+            g_na_bwd_tiled_dQ_bf16_br32_d32 = nil;
+            g_na_bwd_tiled_dQ_bf16_br32 = nil;
+            g_na_bwd_tiled_dQ_bf16_br16 = nil;
+            g_na_bwd_tiled_dKdV_bf16_br32_d32 = nil;
+            g_na_bwd_tiled_dKdV_bf16_br32 = nil;
+            g_na_bwd_tiled_dKdV_bf16_br16 = nil;
+        }
+
+        g_initialized.store(true, std::memory_order_release);
+    }
+
+    return true;
+}
+
+// =============================================================================
+// Generic forward implementation
+// =============================================================================
+
+template <class StdNADim, class StdCausal>
+static void metal_na_forward_impl(
+    at::Tensor& out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& logsumexp,
+    const StdNADim& kernel_size,
+    const StdNADim& stride,
+    const StdNADim& dilation,
+    const StdCausal& is_causal,
+    float attn_scale,
+    const StdNADim& qkv_shape,
+    int num_extra_kv) {
+
+    static constexpr int kNADim = std::tuple_size_v<StdNADim>;
+    static_assert(kNADim >= 1 && kNADim <= 3);
+    static_assert(std::tuple_size_v<StdCausal> == kNADim);
+
+    TORCH_CHECK(query.is_mps(), "query must be on MPS device");
+    TORCH_CHECK(key.is_mps(), "key must be on MPS device");
+    TORCH_CHECK(value.is_mps(), "value must be on MPS device");
+    TORCH_CHECK(out.is_mps(), "output must be on MPS device");
+    TORCH_CHECK(logsumexp.is_mps(), "logsumexp must be on MPS device");
+
+    TORCH_CHECK(query.is_contiguous(), "query must be contiguous");
+    TORCH_CHECK(key.is_contiguous(), "key must be contiguous");
+    TORCH_CHECK(value.is_contiguous(), "value must be contiguous");
+    TORCH_CHECK(out.is_contiguous(), "output must be contiguous");
+    TORCH_CHECK(logsumexp.is_contiguous(), "logsumexp must be contiguous");
+
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D (flattened spatial)");
+
+    init_metal();
+
+    int batch_size = query.size(0);
+    int seqlen_q = query.size(1);
+    int heads_q = query.size(2);
+    int dim = query.size(3);
+    int heads_kv = key.size(2);
+    int seqlen_kv = key.size(1);
+    int dim_value = value.size(3);
+
+    TORCH_CHECK(heads_q >= heads_kv, "heads_q must be >= heads_kv");
+    TORCH_CHECK(heads_q % heads_kv == 0, "heads_q must be divisible by heads_kv");
+    TORCH_CHECK(dim <= 1024, "Metal kernel supports head dim up to 1024");
+    TORCH_CHECK(dim_value <= 1024, "Metal kernel supports value head dim up to 1024");
+
+    TORCH_CHECK(query.scalar_type() == at::kFloat ||
+                query.scalar_type() == at::kHalf ||
+                query.scalar_type() == at::kBFloat16,
+                "Only FP32, FP16, and BF16 are supported");
+
+    bool is_bf16 = query.scalar_type() == at::kBFloat16;
+    bool bf16_fallback = is_bf16 && g_na_fwd_bf16 == nil;
+
+    auto orig_dtype = query.scalar_type();
+    auto query_work = bf16_fallback ? query.to(at::kFloat) : query;
+    auto key_work = bf16_fallback ? key.to(at::kFloat) : key;
+    auto value_work = bf16_fallback ? value.to(at::kFloat) : value;
+    auto out_work = bf16_fallback ? at::empty_like(out, at::kFloat) : out;
+
+    NAParams params;
+    params.batch_size = batch_size;
+    params.seqlen_q = seqlen_q;
+    params.seqlen_kv = seqlen_kv;
+    params.heads_q = heads_q;
+    params.heads_kv = heads_kv;
+    params.dim = dim;
+    params.dim_value = dim_value;
+    params.num_additional_kv = num_extra_kv;
+    params.attn_scale = attn_scale;
+    params.na_dim = kNADim;
+
+    for (int i = 0; i < 3; i++) {
+        params.qkv_shape[i] = 1;
+        params.window_size[i] = 1;
+        params.stride[i] = 1;
+        params.dilation[i] = 1;
+        params.is_causal[i] = 0;
+    }
+
+    if constexpr (kNADim >= 1) {
+        params.qkv_shape[0] = std::get<0>(qkv_shape);
+        params.window_size[0] = std::get<0>(kernel_size);
+        params.stride[0] = std::get<0>(stride);
+        params.dilation[0] = std::get<0>(dilation);
+        params.is_causal[0] = std::get<0>(is_causal) ? 1 : 0;
+    }
+    if constexpr (kNADim >= 2) {
+        params.qkv_shape[1] = std::get<1>(qkv_shape);
+        params.window_size[1] = std::get<1>(kernel_size);
+        params.stride[1] = std::get<1>(stride);
+        params.dilation[1] = std::get<1>(dilation);
+        params.is_causal[1] = std::get<1>(is_causal) ? 1 : 0;
+    }
+    if constexpr (kNADim >= 3) {
+        params.qkv_shape[2] = std::get<2>(qkv_shape);
+        params.window_size[2] = std::get<2>(kernel_size);
+        params.stride[2] = std::get<2>(stride);
+        params.dilation[2] = std::get<2>(dilation);
+        params.is_causal[2] = std::get<2>(is_causal) ? 1 : 0;
+    }
+
+    // Decide whether to use tiled (flash-attention) or reference kernel
+    // Tiled kernel: D <= 128, no additional KV tokens (tiled kernel handles them
+    // but reference is simpler for edge cases)
+    bool use_tiled = (dim <= 128) && (dim_value <= 128);
+
+    @autoreleasepool {
+        auto stream = at::mps::getCurrentMPSStream();
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+
+        id<MTLBuffer> q_buf = at::native::mps::getMTLBufferStorage(query_work);
+        id<MTLBuffer> k_buf = at::native::mps::getMTLBufferStorage(key_work);
+        id<MTLBuffer> v_buf = at::native::mps::getMTLBufferStorage(value_work);
+        id<MTLBuffer> o_buf = at::native::mps::getMTLBufferStorage(out_work);
+        id<MTLBuffer> lse_buf = at::native::mps::getMTLBufferStorage(logsumexp);
+
+        [encoder setBuffer:q_buf offset:query_work.storage_offset() * query_work.element_size() atIndex:0];
+        [encoder setBuffer:k_buf offset:key_work.storage_offset() * key_work.element_size() atIndex:1];
+        [encoder setBuffer:v_buf offset:value_work.storage_offset() * value_work.element_size() atIndex:2];
+        [encoder setBuffer:o_buf offset:out_work.storage_offset() * out_work.element_size() atIndex:3];
+        [encoder setBuffer:lse_buf offset:logsumexp.storage_offset() * logsumexp.element_size() atIndex:4];
+        [encoder setBytes:&params length:sizeof(NAParams) atIndex:5];
+
+        if (use_tiled) {
+            // Select tiled pipeline based on dtype and head dimension
+            id<MTLComputePipelineState> pipeline;
+            int Br;
+            if (dim <= 32 && dim_value <= 32) {
+                Br = 32;
+                if (query_work.scalar_type() == at::kHalf) {
+                    pipeline = g_na_fwd_tiled_fp16_br32_d32;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    pipeline = g_na_fwd_tiled_bf16_br32_d32;
+                } else {
+                    pipeline = g_na_fwd_tiled_fp32_br32_d32;
+                }
+            } else if (dim <= 64 && dim_value <= 64) {
+                Br = 32;
+                if (query_work.scalar_type() == at::kHalf) {
+                    pipeline = g_na_fwd_tiled_fp16_br32;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    pipeline = g_na_fwd_tiled_bf16_br32;
+                } else {
+                    pipeline = g_na_fwd_tiled_fp32_br32;
+                }
+            } else {
+                Br = 16;
+                if (query_work.scalar_type() == at::kHalf) {
+                    pipeline = g_na_fwd_tiled_fp16_br16;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    pipeline = g_na_fwd_tiled_bf16_br16;
+                } else {
+                    pipeline = g_na_fwd_tiled_fp32_br16;
+                }
+            }
+
+            // Fallback to reference if tiled pipeline unavailable (e.g. BF16 not supported)
+            if (pipeline == nil) {
+                use_tiled = false;
+            } else {
+                [encoder setComputePipelineState:pipeline];
+                int num_q_tiles = (seqlen_q + Br - 1) / Br;
+                MTLSize threadgroupCount = MTLSizeMake(num_q_tiles, heads_q * batch_size, 1);
+                MTLSize threadgroupSize = MTLSizeMake(256, 1, 1);
+                [encoder dispatchThreadgroups:threadgroupCount threadsPerThreadgroup:threadgroupSize];
+            }
+        }
+
+        if (!use_tiled) {
+            // Reference kernel: one threadgroup per Q position
+            id<MTLComputePipelineState> pipeline;
+            if (query_work.scalar_type() == at::kHalf) {
+                pipeline = g_na_fwd_fp16;
+            } else if (query_work.scalar_type() == at::kBFloat16) {
+                pipeline = g_na_fwd_bf16;
+            } else {
+                pipeline = g_na_fwd_fp32;
+            }
+            [encoder setComputePipelineState:pipeline];
+
+            MTLSize threadgroupCount = MTLSizeMake(seqlen_q, heads_q * batch_size, 1);
+            MTLSize threadgroupSize = MTLSizeMake(256, 1, 1);
+            [encoder dispatchThreadgroups:threadgroupCount threadsPerThreadgroup:threadgroupSize];
+        }
+
+        // No explicit sync — let PyTorch manage command buffer lifecycle
+    }
+
+    if (bf16_fallback) {
+        out.copy_(out_work.to(orig_dtype));
+    }
+}
+
+// =============================================================================
+// Public API + Pybind11 Bindings (single .mm file, no Swift needed)
+// =============================================================================
+
+static void metal_na1d_forward(
+    at::Tensor& out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& logsumexp,
+    const std::tuple<int32_t>& kernel_size,
+    const std::tuple<int32_t>& stride,
+    const std::tuple<int32_t>& dilation,
+    const std::tuple<bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_forward_impl(
+        out, query, key, value, logsumexp,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+static void metal_na2d_forward(
+    at::Tensor& out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& logsumexp,
+    const std::tuple<int32_t, int32_t>& kernel_size,
+    const std::tuple<int32_t, int32_t>& stride,
+    const std::tuple<int32_t, int32_t>& dilation,
+    const std::tuple<bool, bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t, int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_forward_impl(
+        out, query, key, value, logsumexp,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+static void metal_na3d_forward(
+    at::Tensor& out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    at::Tensor& logsumexp,
+    const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
+    const std::tuple<int32_t, int32_t, int32_t>& stride,
+    const std::tuple<int32_t, int32_t, int32_t>& dilation,
+    const std::tuple<bool, bool, bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t, int32_t, int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_forward_impl(
+        out, query, key, value, logsumexp,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+// =============================================================================
+// Generic backward implementation
+// =============================================================================
+
+template <class StdNADim, class StdCausal>
+static void metal_na_backward_impl(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& output,
+    const at::Tensor& d_output,
+    const at::Tensor& logsumexp,
+    at::Tensor& d_query,
+    at::Tensor& d_key,
+    at::Tensor& d_value,
+    const StdNADim& kernel_size,
+    const StdNADim& stride,
+    const StdNADim& dilation,
+    const StdCausal& is_causal,
+    float attn_scale,
+    const StdNADim& qkv_shape,
+    int num_extra_kv) {
+
+    static constexpr int kNADim = std::tuple_size_v<StdNADim>;
+    static_assert(kNADim >= 1 && kNADim <= 3);
+    static_assert(std::tuple_size_v<StdCausal> == kNADim);
+
+    TORCH_CHECK(query.is_mps(), "query must be on MPS device");
+    TORCH_CHECK(key.is_mps(), "key must be on MPS device");
+    TORCH_CHECK(value.is_mps(), "value must be on MPS device");
+    TORCH_CHECK(output.is_mps(), "output must be on MPS device");
+    TORCH_CHECK(d_output.is_mps(), "d_output must be on MPS device");
+    TORCH_CHECK(logsumexp.is_mps(), "logsumexp must be on MPS device");
+
+    TORCH_CHECK(query.is_contiguous(), "query must be contiguous");
+    TORCH_CHECK(key.is_contiguous(), "key must be contiguous");
+    TORCH_CHECK(value.is_contiguous(), "value must be contiguous");
+    TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
+    TORCH_CHECK(d_output.is_contiguous(), "d_output must be contiguous");
+    TORCH_CHECK(logsumexp.is_contiguous(), "logsumexp must be contiguous");
+    TORCH_CHECK(d_query.is_contiguous(), "d_query must be contiguous");
+    TORCH_CHECK(d_key.is_contiguous(), "d_key must be contiguous");
+    TORCH_CHECK(d_value.is_contiguous(), "d_value must be contiguous");
+
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D (flattened spatial)");
+
+    init_metal();
+
+    int batch_size = query.size(0);
+    int seqlen_q = query.size(1);
+    int heads_q = query.size(2);
+    int dim = query.size(3);
+    int heads_kv = key.size(2);
+    int seqlen_kv = key.size(1);
+    int dim_value = value.size(3);
+
+    TORCH_CHECK(heads_q >= heads_kv, "heads_q must be >= heads_kv");
+    TORCH_CHECK(heads_q % heads_kv == 0, "heads_q must be divisible by heads_kv");
+    TORCH_CHECK(dim <= 1024, "Metal kernel supports head dim up to 1024");
+    TORCH_CHECK(dim_value <= 1024, "Metal kernel supports value head dim up to 1024");
+
+    TORCH_CHECK(query.scalar_type() == at::kFloat ||
+                query.scalar_type() == at::kHalf ||
+                query.scalar_type() == at::kBFloat16,
+                "Only FP32, FP16, and BF16 are supported");
+
+    bool is_bf16 = query.scalar_type() == at::kBFloat16;
+    bool bf16_fallback = is_bf16 && g_na_bwd_dQ_bf16 == nil;
+
+    auto orig_dtype = query.scalar_type();
+    auto query_work = bf16_fallback ? query.to(at::kFloat) : query;
+    auto key_work = bf16_fallback ? key.to(at::kFloat) : key;
+    auto value_work = bf16_fallback ? value.to(at::kFloat) : value;
+    auto output_work = bf16_fallback ? output.to(at::kFloat) : output;
+    auto d_output_work = bf16_fallback ? d_output.to(at::kFloat) : d_output;
+    auto d_query_work = bf16_fallback ? at::zeros_like(d_query, at::kFloat) : d_query;
+    auto d_key_work = bf16_fallback ? at::zeros_like(d_key, at::kFloat) : d_key;
+    auto d_value_work = bf16_fallback ? at::zeros_like(d_value, at::kFloat) : d_value;
+
+    NAParams params;
+    params.batch_size = batch_size;
+    params.seqlen_q = seqlen_q;
+    params.seqlen_kv = seqlen_kv;
+    params.heads_q = heads_q;
+    params.heads_kv = heads_kv;
+    params.dim = dim;
+    params.dim_value = dim_value;
+    params.num_additional_kv = num_extra_kv;
+    params.attn_scale = attn_scale;
+    params.na_dim = kNADim;
+
+    for (int i = 0; i < 3; i++) {
+        params.qkv_shape[i] = 1;
+        params.window_size[i] = 1;
+        params.stride[i] = 1;
+        params.dilation[i] = 1;
+        params.is_causal[i] = 0;
+    }
+
+    if constexpr (kNADim >= 1) {
+        params.qkv_shape[0] = std::get<0>(qkv_shape);
+        params.window_size[0] = std::get<0>(kernel_size);
+        params.stride[0] = std::get<0>(stride);
+        params.dilation[0] = std::get<0>(dilation);
+        params.is_causal[0] = std::get<0>(is_causal) ? 1 : 0;
+    }
+    if constexpr (kNADim >= 2) {
+        params.qkv_shape[1] = std::get<1>(qkv_shape);
+        params.window_size[1] = std::get<1>(kernel_size);
+        params.stride[1] = std::get<1>(stride);
+        params.dilation[1] = std::get<1>(dilation);
+        params.is_causal[1] = std::get<1>(is_causal) ? 1 : 0;
+    }
+    if constexpr (kNADim >= 3) {
+        params.qkv_shape[2] = std::get<2>(qkv_shape);
+        params.window_size[2] = std::get<2>(kernel_size);
+        params.stride[2] = std::get<2>(stride);
+        params.dilation[2] = std::get<2>(dilation);
+        params.is_causal[2] = std::get<2>(is_causal) ? 1 : 0;
+    }
+
+    @autoreleasepool {
+        auto stream = at::mps::getCurrentMPSStream();
+
+        id<MTLBuffer> q_buf = at::native::mps::getMTLBufferStorage(query_work);
+        id<MTLBuffer> k_buf = at::native::mps::getMTLBufferStorage(key_work);
+        id<MTLBuffer> v_buf = at::native::mps::getMTLBufferStorage(value_work);
+        id<MTLBuffer> o_buf = at::native::mps::getMTLBufferStorage(output_work);
+        id<MTLBuffer> do_buf = at::native::mps::getMTLBufferStorage(d_output_work);
+        id<MTLBuffer> lse_buf = at::native::mps::getMTLBufferStorage(logsumexp);
+        id<MTLBuffer> dq_buf = at::native::mps::getMTLBufferStorage(d_query_work);
+        id<MTLBuffer> dk_buf = at::native::mps::getMTLBufferStorage(d_key_work);
+        id<MTLBuffer> dv_buf = at::native::mps::getMTLBufferStorage(d_value_work);
+
+        size_t q_off = query_work.storage_offset() * query_work.element_size();
+        size_t k_off = key_work.storage_offset() * key_work.element_size();
+        size_t v_off = value_work.storage_offset() * value_work.element_size();
+        size_t o_off = output_work.storage_offset() * output_work.element_size();
+        size_t do_off = d_output_work.storage_offset() * d_output_work.element_size();
+        size_t lse_off = logsumexp.storage_offset() * logsumexp.element_size();
+        size_t dq_off = d_query_work.storage_offset() * d_query_work.element_size();
+        size_t dk_off = d_key_work.storage_offset() * d_key_work.element_size();
+        size_t dv_off = d_value_work.storage_offset() * d_value_work.element_size();
+
+        bool use_tiled_bwd = (dim <= 128) && (dim_value <= 128);
+
+        MTLSize threadgroupSize = MTLSizeMake(256, 1, 1);
+
+        if (use_tiled_bwd) {
+            int Br;
+            id<MTLComputePipelineState> tiled_dq_pipeline, tiled_dkdv_pipeline;
+
+            if (dim <= 32 && dim_value <= 32) {
+                Br = 32;
+                if (query_work.scalar_type() == at::kHalf) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp16_br32_d32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp16_br32_d32;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_bf16_br32_d32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_bf16_br32_d32;
+                } else {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp32_br32_d32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp32_br32_d32;
+                }
+            } else if (dim <= 64 && dim_value <= 64) {
+                Br = 32;
+                if (query_work.scalar_type() == at::kHalf) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp16_br32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp16_br32;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_bf16_br32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_bf16_br32;
+                } else {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp32_br32;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp32_br32;
+                }
+            } else {
+                Br = 16;
+                if (query_work.scalar_type() == at::kHalf) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp16_br16;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp16_br16;
+                } else if (query_work.scalar_type() == at::kBFloat16) {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_bf16_br16;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_bf16_br16;
+                } else {
+                    tiled_dq_pipeline = g_na_bwd_tiled_dQ_fp32_br16;
+                    tiled_dkdv_pipeline = g_na_bwd_tiled_dKdV_fp32_br16;
+                }
+            }
+
+            if (!tiled_dq_pipeline || !tiled_dkdv_pipeline) {
+                use_tiled_bwd = false;
+            } else {
+                // ---- Tiled dQ kernel ----
+                {
+                    id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+                    [encoder setComputePipelineState:tiled_dq_pipeline];
+                    [encoder setBuffer:q_buf offset:q_off atIndex:0];
+                    [encoder setBuffer:k_buf offset:k_off atIndex:1];
+                    [encoder setBuffer:v_buf offset:v_off atIndex:2];
+                    [encoder setBuffer:do_buf offset:do_off atIndex:3];
+                    [encoder setBuffer:lse_buf offset:lse_off atIndex:4];
+                    [encoder setBuffer:o_buf offset:o_off atIndex:5];
+                    [encoder setBuffer:dq_buf offset:dq_off atIndex:6];
+                    [encoder setBytes:&params length:sizeof(NAParams) atIndex:7];
+
+                    int num_q_tiles = (seqlen_q + Br - 1) / Br;
+                    MTLSize dq_grid = MTLSizeMake(num_q_tiles, heads_q * batch_size, 1);
+                    [encoder dispatchThreadgroups:dq_grid threadsPerThreadgroup:threadgroupSize];
+                }
+
+                // ---- Tiled dKdV kernel ----
+                {
+                    id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+                    [encoder setComputePipelineState:tiled_dkdv_pipeline];
+                    [encoder setBuffer:q_buf offset:q_off atIndex:0];
+                    [encoder setBuffer:k_buf offset:k_off atIndex:1];
+                    [encoder setBuffer:v_buf offset:v_off atIndex:2];
+                    [encoder setBuffer:do_buf offset:do_off atIndex:3];
+                    [encoder setBuffer:lse_buf offset:lse_off atIndex:4];
+                    [encoder setBuffer:o_buf offset:o_off atIndex:5];
+                    [encoder setBuffer:dk_buf offset:dk_off atIndex:6];
+                    [encoder setBuffer:dv_buf offset:dv_off atIndex:7];
+                    [encoder setBytes:&params length:sizeof(NAParams) atIndex:8];
+
+                    int num_kv_tiles = (seqlen_kv + Br - 1) / Br;
+                    MTLSize dkdv_grid = MTLSizeMake(num_kv_tiles, heads_kv * batch_size, 1);
+                    [encoder dispatchThreadgroups:dkdv_grid threadsPerThreadgroup:threadgroupSize];
+                }
+            }
+        }
+
+        if (!use_tiled_bwd) {
+            // Reference backward kernels (fallback for D > 128 or missing pipelines)
+            id<MTLComputePipelineState> dq_pipeline, dk_pipeline, dv_pipeline;
+            if (query_work.scalar_type() == at::kHalf) {
+                dq_pipeline = g_na_bwd_dQ_fp16;
+                dk_pipeline = g_na_bwd_dK_fp16;
+                dv_pipeline = g_na_bwd_dV_fp16;
+            } else if (query_work.scalar_type() == at::kBFloat16) {
+                dq_pipeline = g_na_bwd_dQ_bf16;
+                dk_pipeline = g_na_bwd_dK_bf16;
+                dv_pipeline = g_na_bwd_dV_bf16;
+            } else {
+                dq_pipeline = g_na_bwd_dQ_fp32;
+                dk_pipeline = g_na_bwd_dK_fp32;
+                dv_pipeline = g_na_bwd_dV_fp32;
+            }
+
+            // ---- dQ kernel: grid = (seqlen_q, heads_q * batch_size) ----
+            {
+                id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+                [encoder setComputePipelineState:dq_pipeline];
+                [encoder setBuffer:q_buf offset:q_off atIndex:0];
+                [encoder setBuffer:k_buf offset:k_off atIndex:1];
+                [encoder setBuffer:v_buf offset:v_off atIndex:2];
+                [encoder setBuffer:o_buf offset:o_off atIndex:3];
+                [encoder setBuffer:do_buf offset:do_off atIndex:4];
+                [encoder setBuffer:lse_buf offset:lse_off atIndex:5];
+                [encoder setBuffer:dq_buf offset:dq_off atIndex:6];
+                [encoder setBytes:&params length:sizeof(NAParams) atIndex:7];
+
+                MTLSize dq_grid = MTLSizeMake(seqlen_q, heads_q * batch_size, 1);
+                [encoder dispatchThreadgroups:dq_grid threadsPerThreadgroup:threadgroupSize];
+            }
+
+            // ---- dK kernel: grid = (seqlen_kv, heads_kv * batch_size) ----
+            {
+                id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+                [encoder setComputePipelineState:dk_pipeline];
+                [encoder setBuffer:q_buf offset:q_off atIndex:0];
+                [encoder setBuffer:k_buf offset:k_off atIndex:1];
+                [encoder setBuffer:v_buf offset:v_off atIndex:2];
+                [encoder setBuffer:o_buf offset:o_off atIndex:3];
+                [encoder setBuffer:do_buf offset:do_off atIndex:4];
+                [encoder setBuffer:lse_buf offset:lse_off atIndex:5];
+                [encoder setBuffer:dk_buf offset:dk_off atIndex:6];
+                [encoder setBytes:&params length:sizeof(NAParams) atIndex:7];
+
+                MTLSize dk_grid = MTLSizeMake(seqlen_kv, heads_kv * batch_size, 1);
+                [encoder dispatchThreadgroups:dk_grid threadsPerThreadgroup:threadgroupSize];
+            }
+
+            // ---- dV kernel: grid = (seqlen_kv, heads_kv * batch_size) ----
+            {
+                id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+                [encoder setComputePipelineState:dv_pipeline];
+                [encoder setBuffer:q_buf offset:q_off atIndex:0];
+                [encoder setBuffer:k_buf offset:k_off atIndex:1];
+                [encoder setBuffer:v_buf offset:v_off atIndex:2];
+                [encoder setBuffer:o_buf offset:o_off atIndex:3];
+                [encoder setBuffer:do_buf offset:do_off atIndex:4];
+                [encoder setBuffer:lse_buf offset:lse_off atIndex:5];
+                [encoder setBuffer:dv_buf offset:dv_off atIndex:6];
+                [encoder setBytes:&params length:sizeof(NAParams) atIndex:7];
+
+                MTLSize dv_grid = MTLSizeMake(seqlen_kv, heads_kv * batch_size, 1);
+                [encoder dispatchThreadgroups:dv_grid threadsPerThreadgroup:threadgroupSize];
+            }
+        }
+
+        // No explicit sync — let PyTorch manage command buffer lifecycle
+    }
+
+    if (bf16_fallback) {
+        d_query.copy_(d_query_work.to(orig_dtype));
+        d_key.copy_(d_key_work.to(orig_dtype));
+        d_value.copy_(d_value_work.to(orig_dtype));
+    }
+}
+
+// =============================================================================
+// Backward Public API
+// =============================================================================
+
+static void metal_na1d_backward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& output,
+    const at::Tensor& d_output,
+    const at::Tensor& logsumexp,
+    at::Tensor& d_query,
+    at::Tensor& d_key,
+    at::Tensor& d_value,
+    const std::tuple<int32_t>& kernel_size,
+    const std::tuple<int32_t>& stride,
+    const std::tuple<int32_t>& dilation,
+    const std::tuple<bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_backward_impl(
+        query, key, value, output, d_output, logsumexp,
+        d_query, d_key, d_value,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+static void metal_na2d_backward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& output,
+    const at::Tensor& d_output,
+    const at::Tensor& logsumexp,
+    at::Tensor& d_query,
+    at::Tensor& d_key,
+    at::Tensor& d_value,
+    const std::tuple<int32_t, int32_t>& kernel_size,
+    const std::tuple<int32_t, int32_t>& stride,
+    const std::tuple<int32_t, int32_t>& dilation,
+    const std::tuple<bool, bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t, int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_backward_impl(
+        query, key, value, output, d_output, logsumexp,
+        d_query, d_key, d_value,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+static void metal_na3d_backward(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& output,
+    const at::Tensor& d_output,
+    const at::Tensor& logsumexp,
+    at::Tensor& d_query,
+    at::Tensor& d_key,
+    at::Tensor& d_value,
+    const std::tuple<int32_t, int32_t, int32_t>& kernel_size,
+    const std::tuple<int32_t, int32_t, int32_t>& stride,
+    const std::tuple<int32_t, int32_t, int32_t>& dilation,
+    const std::tuple<bool, bool, bool>& is_causal,
+    float attn_scale,
+    const std::tuple<int32_t, int32_t, int32_t>& qkv_shape,
+    int num_extra_kv) {
+    TORCH_CHECK(query.dim() == 4, "Tensors must be 4-D.");
+    metal_na_backward_impl(
+        query, key, value, output, d_output, logsumexp,
+        d_query, d_key, d_value,
+        kernel_size, stride, dilation, is_causal,
+        attn_scale, qkv_shape, num_extra_kv);
+}
+
+PYBIND11_MODULE(_metal_natten, m) {
+    m.doc() = "NATTEN Metal backend for MPS (Apple Silicon)";
+
+    m.def("metal_na1d_forward", &metal_na1d_forward, "Metal NA1D forward (MPS)");
+    m.def("metal_na2d_forward", &metal_na2d_forward, "Metal NA2D forward (MPS)");
+    m.def("metal_na3d_forward", &metal_na3d_forward, "Metal NA3D forward (MPS)");
+
+    m.def("metal_na1d_backward", &metal_na1d_backward, "Metal NA1D backward (MPS)");
+    m.def("metal_na2d_backward", &metal_na2d_backward, "Metal NA2D backward (MPS)");
+    m.def("metal_na3d_backward", &metal_na3d_backward, "Metal NA3D backward (MPS)");
+}
+

--- a/src/natten/backends/__init__.py
+++ b/src/natten/backends/__init__.py
@@ -61,8 +61,17 @@ from .configs.checks import (
     can_run_cutlass_hopper_fmha,
     can_run_cutlass_hopper_fna,
     can_run_flex_attention,
+    can_run_metal_fmha,
+    can_run_metal_fna,
 )
 from .flex import flex_fmha, flex_fna_generic, na1d_flex, na2d_flex, na3d_flex
+from .metal import (
+    metal_fmha,
+    metal_fna_generic,
+    na1d_metal_fna,
+    na2d_metal_fna,
+    na3d_metal_fna,
+)
 from .fmha import can_run_cutlass_fmha, cutlass_fmha
 from .fna import (
     cutlass_fna_generic,
@@ -93,6 +102,10 @@ def choose_backend(
     if can_run_cutlass_fna(query, key, value):
         logger.debug("Backend not set; picked CUTLASS (2.X) FNA kernel.")
         return "cutlass-fna"
+
+    if can_run_metal_fna(query, key, value):
+        logger.debug("Backend not set; picked Metal FNA kernel (MPS).")
+        return "metal-fna"
 
     if can_run_flex_attention(query, key, value, torch_compile=torch_compile):
         logger.debug("Backend not set; picked Flex Attention kernel.")
@@ -130,6 +143,12 @@ def choose_fmha_backend(
         logger.debug("Backend not set; picked CUTLASS (2.X) FMHA kernel.")
         return "cutlass-fmha"
 
+    if can_run_metal_fmha(
+        query, key, value, is_causal=is_causal, is_varlen=is_varlen
+    ):
+        logger.debug("Backend not set; picked Metal FMHA kernel (MPS).")
+        return "metal-fmha"
+
     if can_run_flex_attention(
         query,
         key,
@@ -159,6 +178,9 @@ def get_compatible_backends(
 
     if can_run_cutlass_fna(query, key, value):
         compatible_backends.append("cutlass-fna")
+
+    if can_run_metal_fna(query, key, value):
+        compatible_backends.append("metal-fna")
 
     if can_run_flex_attention(query, key, value, torch_compile=torch_compile):
         compatible_backends.append("flex-fna")
@@ -190,6 +212,11 @@ def get_compatible_fmha_backends(
     ):
         compatible_backends.append("cutlass-fmha")
 
+    if can_run_metal_fmha(
+        query, key, value, is_causal=is_causal, is_varlen=is_varlen
+    ):
+        compatible_backends.append("metal-fmha")
+
     if can_run_flex_attention(
         query,
         key,
@@ -211,6 +238,8 @@ __all__ = [
     "can_run_cutlass_hopper_fmha",
     "can_run_cutlass_hopper_fna",
     "can_run_flex_attention",
+    "can_run_metal_fmha",
+    "can_run_metal_fna",
     "cutlass_fmha",
     "cutlass_fna_generic",
     "na1d_cutlass_fna",
@@ -228,6 +257,11 @@ __all__ = [
     "na1d_flex",
     "na2d_flex",
     "na3d_flex",
+    "metal_fmha",
+    "metal_fna_generic",
+    "na1d_metal_fna",
+    "na2d_metal_fna",
+    "na3d_metal_fna",
     "na1d_cutlass_hopper_fna",
     "na2d_cutlass_hopper_fna",
     "na3d_cutlass_hopper_fna",

--- a/src/natten/backends/metal.py
+++ b/src/natten/backends/metal.py
@@ -1,0 +1,512 @@
+#################################################################################################
+# Copyright (c) 2022-2025 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.autograd import Function
+
+from ..types import (
+    CausalArg1DTypeOrDed,
+    CausalArg2DTypeOrDed,
+    CausalArg3DTypeOrDed,
+    CausalArgType,
+    CausalArgTypeOrDed,
+    Dimension1DTypeOrDed,
+    Dimension2DTypeOrDed,
+    Dimension3DTypeOrDed,
+    DimensionType,
+    DimensionTypeOrDed,
+    NoneType,
+)
+from ..utils import log
+from ..utils.checks import (
+    additional_kv_tensor_checks,
+    check_all_args,
+    check_args_against_input,
+    fmha_tensor_checks,
+    na_tensor_checks,
+)
+
+logger = log.get_logger(__name__)
+
+try:
+    from natten._metal_natten import (
+        metal_na1d_forward,
+        metal_na2d_forward,
+        metal_na3d_forward,
+        metal_na1d_backward,
+        metal_na2d_backward,
+        metal_na3d_backward,
+    )
+
+    HAS_METAL_NATTEN = True
+except ImportError:
+    HAS_METAL_NATTEN = False
+
+
+def make_metal_fna_autograd_fn(na_dim):
+    assert na_dim in [1, 2, 3]
+
+    FORWARD_OPS = {
+        1: metal_na1d_forward if HAS_METAL_NATTEN else None,
+        2: metal_na2d_forward if HAS_METAL_NATTEN else None,
+        3: metal_na3d_forward if HAS_METAL_NATTEN else None,
+    }
+
+    BACKWARD_OPS = {
+        1: metal_na1d_backward if HAS_METAL_NATTEN else None,
+        2: metal_na2d_backward if HAS_METAL_NATTEN else None,
+        3: metal_na3d_backward if HAS_METAL_NATTEN else None,
+    }
+
+    class MetalFnaAutogradFn(Function):
+        @staticmethod
+        def forward(
+            ctx,
+            query: Tensor,
+            key: Tensor,
+            value: Tensor,
+            kernel_size: DimensionType,
+            stride: DimensionType,
+            dilation: DimensionType,
+            is_causal: CausalArgType,
+            scale: float,
+            qkv_shape: DimensionType,
+            num_extra_kv: int,
+        ) -> Tuple[Tensor, Tensor]:
+            kernel_size, stride, dilation, is_causal = check_all_args(
+                na_dim, kernel_size, stride, dilation, is_causal
+            )
+
+            query = query.contiguous()
+            key = key.contiguous()
+            value = value.contiguous()
+
+            assert query.dim() == value.dim() == 4
+            assert query.shape[0] == value.shape[0]
+
+            batch_size = query.shape[0]
+            seqlen_q = query.shape[1]
+            heads_q = query.shape[2]
+            dim_value = value.shape[3]
+
+            output = torch.empty(
+                batch_size, seqlen_q, heads_q, dim_value,
+                dtype=query.dtype, device=query.device,
+            )
+            logsumexp = torch.empty(
+                batch_size, seqlen_q, heads_q,
+                dtype=torch.float32, device=query.device,
+            )
+
+            FORWARD_OPS[na_dim](
+                output,
+                query,
+                key,
+                value,
+                logsumexp,
+                kernel_size,
+                stride,
+                dilation,
+                is_causal,
+                scale,
+                qkv_shape,
+                num_extra_kv,
+            )
+
+            ctx.save_for_backward(query, key, value, logsumexp, output)
+            ctx.kernel_size = kernel_size
+            ctx.stride = stride
+            ctx.dilation = dilation
+            ctx.is_causal = is_causal
+            ctx.scale = scale
+            ctx.qkv_shape = qkv_shape
+            ctx.num_extra_kv = num_extra_kv
+
+            return output, logsumexp
+
+        @staticmethod
+        def backward(ctx, grad_out: Tensor, grad_lse: Tensor) -> Tuple[
+            Tensor,
+            Tensor,
+            Tensor,
+            NoneType,
+            NoneType,
+            NoneType,
+            NoneType,
+            NoneType,
+            NoneType,
+            NoneType,
+        ]:
+            query, key, value, logsumexp, output = ctx.saved_tensors
+            d_output = grad_out.contiguous()
+
+            d_query = torch.empty_like(query)
+            d_key = torch.empty_like(key)
+            d_value = torch.empty_like(value)
+
+            BACKWARD_OPS[na_dim](
+                query,
+                key,
+                value,
+                output,
+                d_output,
+                logsumexp,
+                d_query,
+                d_key,
+                d_value,
+                ctx.kernel_size,
+                ctx.stride,
+                ctx.dilation,
+                ctx.is_causal,
+                ctx.scale,
+                ctx.qkv_shape,
+                ctx.num_extra_kv,
+            )
+
+            return d_query, d_key, d_value, None, None, None, None, None, None, None
+
+    return MetalFnaAutogradFn
+
+
+MetalFna1DAutogradFn = make_metal_fna_autograd_fn(1)
+MetalFna2DAutogradFn = make_metal_fna_autograd_fn(2)
+MetalFna3DAutogradFn = make_metal_fna_autograd_fn(3)
+
+MetalFnaAutogradFns = {
+    1: MetalFna1DAutogradFn,
+    2: MetalFna2DAutogradFn,
+    3: MetalFna3DAutogradFn,
+}
+
+
+def metal_fna_generic(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: DimensionTypeOrDed,
+    stride: DimensionTypeOrDed = 1,
+    dilation: DimensionTypeOrDed = 1,
+    is_causal: Optional[CausalArgTypeOrDed] = False,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    return_lse: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+
+    if not HAS_METAL_NATTEN:
+        raise RuntimeError(
+            "Metal NATTEN extension is not available. "
+            "Please build with: pip install -e . (on macOS with Apple Silicon)."
+        )
+
+    na_tensor_checks(
+        query, key, value, must_match_head_dims=False, supports_gqa_mqa=True
+    )
+    additional_kv_tensor_checks(
+        query,
+        key,
+        value,
+        additional_keys,
+        additional_values,
+        must_match_head_dims=False,
+        supports_gqa_mqa=True,
+    )
+
+    na_dim = query.dim() - 3  # batch, heads, head_dim
+
+    assert na_dim in [1, 2, 3]
+
+    kernel_size, stride, dilation, is_causal = check_all_args(
+        na_dim, kernel_size, stride, dilation, is_causal
+    )
+
+    check_args_against_input(
+        query,
+        kernel_size=kernel_size,
+        stride=stride,
+        dilation=dilation,
+        is_causal=is_causal,
+    )
+
+    scale = scale or query.shape[-1] ** -0.5
+
+    qkv_shape = query.shape[1 : 1 + na_dim]
+
+    query = query.flatten(1, na_dim)
+    key = key.flatten(1, na_dim)
+    value = value.flatten(1, na_dim)
+
+    num_extra_kv = 0
+    if additional_keys is not None and additional_values is not None:
+        num_extra_kv = additional_keys.shape[1]
+        key = torch.cat([key, additional_keys], dim=1)
+        value = torch.cat([value, additional_values], dim=1)
+
+    output, lse = MetalFnaAutogradFns[na_dim].apply(
+        query,
+        key,
+        value,
+        kernel_size,
+        stride,
+        dilation,
+        is_causal,
+        scale,
+        qkv_shape,
+        num_extra_kv,
+    )
+    output = output.reshape(
+        query.shape[0], *qkv_shape, query.shape[-2], value.shape[-1]
+    )
+    lse = lse.reshape(query.shape[0], *qkv_shape, query.shape[-2])
+
+    if return_lse:
+        return output, lse
+
+    return output
+
+
+def na1d_metal_fna(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension1DTypeOrDed,
+    stride: Dimension1DTypeOrDed = 1,
+    dilation: Dimension1DTypeOrDed = 1,
+    is_causal: Optional[CausalArg1DTypeOrDed] = False,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    return_lse: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    return metal_fna_generic(
+        query=query,
+        key=key,
+        value=value,
+        kernel_size=kernel_size,
+        stride=stride,
+        dilation=dilation,
+        is_causal=is_causal,
+        scale=scale,
+        additional_keys=additional_keys,
+        additional_values=additional_values,
+        return_lse=return_lse,
+    )
+
+
+def na2d_metal_fna(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension2DTypeOrDed,
+    stride: Dimension2DTypeOrDed = 1,
+    dilation: Dimension2DTypeOrDed = 1,
+    is_causal: Optional[CausalArg2DTypeOrDed] = False,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    return_lse: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    return metal_fna_generic(
+        query=query,
+        key=key,
+        value=value,
+        kernel_size=kernel_size,
+        stride=stride,
+        dilation=dilation,
+        is_causal=is_causal,
+        scale=scale,
+        additional_keys=additional_keys,
+        additional_values=additional_values,
+        return_lse=return_lse,
+    )
+
+
+def na3d_metal_fna(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    kernel_size: Dimension3DTypeOrDed,
+    stride: Dimension3DTypeOrDed = 1,
+    dilation: Dimension3DTypeOrDed = 1,
+    is_causal: Optional[CausalArg3DTypeOrDed] = False,
+    scale: Optional[float] = None,
+    additional_keys: Optional[Tensor] = None,
+    additional_values: Optional[Tensor] = None,
+    return_lse: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    return metal_fna_generic(
+        query=query,
+        key=key,
+        value=value,
+        kernel_size=kernel_size,
+        stride=stride,
+        dilation=dilation,
+        is_causal=is_causal,
+        scale=scale,
+        additional_keys=additional_keys,
+        additional_values=additional_values,
+        return_lse=return_lse,
+    )
+
+
+# =============================================================================
+# Metal FMHA — standard full self-attention via the FNA kernel
+# =============================================================================
+
+
+class MetalFmhaAutogradFn(Function):
+    @staticmethod
+    def forward(
+        ctx,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        is_causal: bool,
+        scale: float,
+    ) -> Tuple[Tensor, Tensor]:
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
+
+        assert query.dim() == 4
+
+        seqlen = query.shape[1]
+        batch_size = query.shape[0]
+        heads_q = query.shape[2]
+        dim_value = value.shape[3]
+
+        output = torch.empty(
+            batch_size, seqlen, heads_q, dim_value,
+            dtype=query.dtype, device=query.device,
+        )
+        logsumexp = torch.empty(
+            batch_size, seqlen, heads_q,
+            dtype=torch.float32, device=query.device,
+        )
+
+        kernel_size = (seqlen,)
+        stride_t = (1,)
+        dilation_t = (1,)
+        is_causal_tuple = (is_causal,)
+        qkv_shape = (seqlen,)
+
+        metal_na1d_forward(
+            output,
+            query,
+            key,
+            value,
+            logsumexp,
+            kernel_size,
+            stride_t,
+            dilation_t,
+            is_causal_tuple,
+            scale,
+            qkv_shape,
+            0,
+        )
+
+        ctx.save_for_backward(query, key, value, logsumexp, output)
+        ctx.is_causal = is_causal
+        ctx.scale = scale
+
+        return output, logsumexp
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor, grad_lse: Tensor) -> Tuple[
+        Tensor,
+        Tensor,
+        Tensor,
+        NoneType,
+        NoneType,
+    ]:
+        query, key, value, logsumexp, output = ctx.saved_tensors
+        d_output = grad_out.contiguous()
+
+        seqlen = query.shape[1]
+
+        d_query = torch.empty_like(query)
+        d_key = torch.empty_like(key)
+        d_value = torch.empty_like(value)
+
+        kernel_size = (seqlen,)
+        stride_t = (1,)
+        dilation_t = (1,)
+        is_causal_tuple = (ctx.is_causal,)
+        qkv_shape = (seqlen,)
+
+        metal_na1d_backward(
+            query,
+            key,
+            value,
+            output,
+            d_output,
+            logsumexp,
+            d_query,
+            d_key,
+            d_value,
+            kernel_size,
+            stride_t,
+            dilation_t,
+            is_causal_tuple,
+            ctx.scale,
+            qkv_shape,
+            0,
+        )
+
+        return d_query, d_key, d_value, None, None
+
+
+def metal_fmha(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    is_causal: bool = False,
+    scale: Optional[float] = None,
+    return_lse: bool = False,
+    **kwargs,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+
+    if not HAS_METAL_NATTEN:
+        raise RuntimeError(
+            "Metal NATTEN extension is not available. "
+            "Please build with: pip install -e . (on macOS with Apple Silicon)."
+        )
+
+    fmha_tensor_checks(
+        query, key, value, must_match_head_dims=False, supports_gqa_mqa=True
+    )
+
+    assert query.dim() == 4
+
+    scale = scale or query.shape[-1] ** -0.5
+
+    output, lse = MetalFmhaAutogradFn.apply(
+        query, key, value, is_causal, scale,
+    )
+
+    if return_lse:
+        return output, lse
+
+    return output

--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -37,6 +37,8 @@ from .backends import (
     cutlass_hopper_fna_generic,
     flex_fmha,
     flex_fna_generic,
+    metal_fmha,
+    metal_fna_generic,
 )
 from .types import (
     CausalArg1DTypeOrDed,
@@ -328,6 +330,16 @@ def attention(
             max_seqlen_KV=max_seqlen_KV,
         )
 
+    elif backend == "metal-fmha":
+        return metal_fmha(
+            query=query,
+            key=key,
+            value=value,
+            is_causal=is_causal,
+            scale=scale,
+            return_lse=return_lse,
+        )
+
     elif backend == "flex-fmha":
         return flex_fmha(
             query=query,
@@ -499,6 +511,19 @@ def neighborhood_attention_generic(
             backward_kv_tile_shape=backward_kv_tile_shape,
             backward_kv_splits=backward_kv_splits,
             backward_use_pt_reduction=backward_use_pt_reduction,
+            return_lse=True,
+        )
+
+    elif backend == "metal-fna":
+        output, lse = metal_fna_generic(
+            query=query,
+            key=key,
+            value=value,
+            kernel_size=kernel_size,
+            stride=stride,
+            dilation=dilation,
+            is_causal=is_causal,
+            scale=scale,
             return_lse=True,
         )
 

--- a/src/natten/profiling_utils/formatting.py
+++ b/src/natten/profiling_utils/formatting.py
@@ -51,11 +51,23 @@ NATTEN_TAGS = {
         "cutlass::fna::kernel::Sm100FnaFwdKernelTmaWarpspecialized",
         "cutlass::fna::collective::FnaMainloopTmaWarpSpecializedSm90",
         "cutlass::fna::collective::FnaMainloopTmaSm90",
+        "na_forward_fp32",
+        "na_forward_fp16",
+        "na_forward_bf16",
     ],
     LibNattenOp.FnaBackward: [
         "natten::cuda::fna::FusedNeighborhoodAttentionBackwardKernel<",
         "cutlass::fna::collective::FnaBwdMainloopTmaWarpSpecializedSm90",
         "cutlass::fna::kernel::Sm100FnaBwdKernelTmaWarpSpecialized",
+        "na_backward_dQ_fp32",
+        "na_backward_dQ_fp16",
+        "na_backward_dQ_bf16",
+        "na_backward_dK_fp32",
+        "na_backward_dK_fp16",
+        "na_backward_dK_bf16",
+        "na_backward_dV_fp32",
+        "na_backward_dV_fp16",
+        "na_backward_dV_bf16",
     ],
     LibNattenOp.FmhaForward: [
         "cutlass::fmha::kernel::Sm100FmhaFwdKernelTmaWarpspecialized",
@@ -281,6 +293,7 @@ ARCH_LOOKUP = {
     "Sm100": ["sm100", "blackwell"],
     "Sm101": ["sm101"],
     "Sm120": ["sm120"],
+    "Apple": ["na_forward_", "na_backward_"],
 }
 
 
@@ -288,6 +301,7 @@ FRAMEWORK_LOOKUP = {
     "CUTLASS": ["cutlass", "cute"],
     "cuDNN": ["cudnn"],
     "cuBLAS": ["cublas"],
+    "Metal": ["na_forward_", "na_backward_"],
     "PyTorch": ["c10", "aten", "at::native"],
     "Triton": ["triton"],
 }
@@ -330,6 +344,9 @@ def convert_to_natten_profiler_ops(
         time_total = (
             evt.device_time_total if torch.cuda.is_available() else evt.cpu_time_total
         )
+        # On MPS, device_time_total is 0; use cpu_time_total instead
+        if time_total == 0 and evt.cpu_time_total > 0:
+            time_total = evt.cpu_time_total
 
         natten_op = get_natten_op(evt.key)
         arch_tag = get_arch(evt.key)

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -1,0 +1,1358 @@
+#################################################################################################
+# Copyright (c) 2022-2025 Ali Hassani.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#################################################################################################
+
+"""
+Comprehensive tests for the NATTEN Metal (MPS) backend.
+Covers forward correctness, backward correctness, FMHA, GQA, causal, dilation, stride, dtypes.
+"""
+
+import unittest
+
+import torch
+
+HAS_MPS = torch.backends.mps.is_available()
+
+try:
+    import natten
+    from natten.backends.metal import HAS_METAL_NATTEN
+except ImportError:
+    HAS_METAL_NATTEN = False
+
+
+def skip_if_no_mps(fn):
+    return unittest.skipUnless(HAS_MPS, "MPS device not available")(fn)
+
+
+def skip_if_no_metal(fn):
+    return unittest.skipUnless(HAS_MPS and HAS_METAL_NATTEN, "Metal NATTEN not available")(fn)
+
+
+def _get_win_start_1d(index, window_left, window_right, stride, length, is_causal):
+    """Compute window start for 1D NA, matching mask.hpp exactly."""
+    if is_causal:
+        leader = min((index // stride) * stride + stride - 1, length - 1)
+        return max(leader - window_left - window_right, 0)
+    else:
+        leader = min((index // stride) * stride + (stride // 2), length - 1)
+        return max(leader - window_left, 0) + (
+            (leader + window_right >= length) * (length - window_right - leader - 1)
+        )
+
+
+def _get_win_end_1d(index, start, window_size, length, is_causal):
+    """Compute window end for 1D NA, matching mask.hpp exactly."""
+    if is_causal:
+        return min(index + 1, length)
+    else:
+        return start + window_size
+
+
+def _qkv_fix_dilation(qkv_shape, dilation, dilation_group):
+    """Correct effective sequence length for a dilation group."""
+    padding = 1 - ((dilation_group + (dilation - (qkv_shape % dilation))) // dilation)
+    return (qkv_shape // dilation) + padding
+
+
+def naive_na1d_forward(query, key, value, kernel_size, is_causal=False, scale=None,
+                       stride=1, dilation=1):
+    """Pure PyTorch reference for NA1D forward with stride, dilation, GQA support."""
+    B, S, H, D = query.shape
+    DV = value.shape[-1]
+    HKV = key.shape[2]
+    scale = scale or D ** -0.5
+
+    wl = kernel_size // 2
+    wr = (kernel_size // 2) + ((kernel_size % 2) - 1)
+
+    output = torch.zeros(B, S, H, DV, dtype=query.dtype, device=query.device)
+    lse = torch.zeros(B, S, H, dtype=torch.float32, device=query.device)
+
+    for b in range(B):
+        for i in range(S):
+            for h in range(H):
+                h_kv = h // (H // HKV) if HKV != H else h
+
+                # Dilation: decompose into dilation group coordinates
+                di_group = i % dilation
+                q_coord = i // dilation
+
+                # Corrected shape for this dilation group
+                eff_len = _qkv_fix_dilation(S, dilation, di_group)
+
+                start = _get_win_start_1d(q_coord, wl, wr, stride, eff_len, is_causal)
+                end = _get_win_end_1d(q_coord, start, kernel_size, eff_len, is_causal)
+
+                q_vec = query[b, i, h, :].float()
+                scores = []
+                indices = []
+                for j_inner in range(start, end):
+                    # Map back to global index
+                    j_global = j_inner * dilation + di_group
+                    if j_global >= S:
+                        continue
+                    k_vec = key[b, j_global, h_kv, :].float()
+                    s = (q_vec * k_vec).sum() * scale
+                    scores.append(s)
+                    indices.append(j_global)
+
+                if len(scores) == 0:
+                    continue
+
+                scores_t = torch.stack(scores)
+                max_s = scores_t.max()
+                exp_s = torch.exp(scores_t - max_s)
+                sum_s = exp_s.sum()
+
+                lse[b, i, h] = torch.log(sum_s) + max_s
+
+                weights = exp_s / sum_s
+                acc = torch.zeros(DV, dtype=torch.float32, device=query.device)
+                for w, j in zip(weights, indices):
+                    acc += w * value[b, j, h_kv, :].float()
+
+                output[b, i, h, :] = acc.to(query.dtype)
+
+    return output, lse
+
+
+def naive_na2d_forward(query, key, value, kernel_size, is_causal=(False, False),
+                       scale=None, stride=(1, 1), dilation=(1, 1)):
+    """Pure PyTorch reference for NA2D forward with stride, dilation, GQA support.
+    query: [B, Hsp, Wsp, H, D], key: [B, Hsp, Wsp, HKV, D], value: [B, Hsp, Wsp, HKV, DV]
+    kernel_size, stride, dilation: 2-tuples
+    """
+    B, Hsp, Wsp, H, D = query.shape
+    DV = value.shape[-1]
+    HKV = key.shape[3]
+    scale = scale or D ** -0.5
+    ks_h, ks_w = kernel_size
+    str_h, str_w = stride
+    dil_h, dil_w = dilation
+
+    wl_h, wl_w = ks_h // 2, ks_w // 2
+    wr_h = (ks_h // 2) + ((ks_h % 2) - 1)
+    wr_w = (ks_w // 2) + ((ks_w % 2) - 1)
+
+    output = torch.zeros(B, Hsp, Wsp, H, DV, dtype=query.dtype, device=query.device)
+
+    for b in range(B):
+        for ih in range(Hsp):
+            for iw in range(Wsp):
+                for h in range(H):
+                    h_kv = h // (H // HKV) if HKV != H else h
+
+                    # Dilation decomposition for each dimension
+                    di_h = ih % dil_h
+                    di_w = iw % dil_w
+                    qc_h = ih // dil_h
+                    qc_w = iw // dil_w
+
+                    eff_h = _qkv_fix_dilation(Hsp, dil_h, di_h)
+                    eff_w = _qkv_fix_dilation(Wsp, dil_w, di_w)
+
+                    start_h = _get_win_start_1d(qc_h, wl_h, wr_h, str_h, eff_h, is_causal[0])
+                    end_h = _get_win_end_1d(qc_h, start_h, ks_h, eff_h, is_causal[0])
+                    start_w = _get_win_start_1d(qc_w, wl_w, wr_w, str_w, eff_w, is_causal[1])
+                    end_w = _get_win_end_1d(qc_w, start_w, ks_w, eff_w, is_causal[1])
+
+                    q_vec = query[b, ih, iw, h, :].float()
+                    scores = []
+                    kv_indices = []
+                    for jh_inner in range(start_h, end_h):
+                        for jw_inner in range(start_w, end_w):
+                            jh = jh_inner * dil_h + di_h
+                            jw = jw_inner * dil_w + di_w
+                            if jh >= Hsp or jw >= Wsp:
+                                continue
+                            k_vec = key[b, jh, jw, h_kv, :].float()
+                            s = (q_vec * k_vec).sum() * scale
+                            scores.append(s)
+                            kv_indices.append((jh, jw))
+
+                    if len(scores) == 0:
+                        continue
+
+                    scores_t = torch.stack(scores)
+                    max_s = scores_t.max()
+                    exp_s = torch.exp(scores_t - max_s)
+                    sum_s = exp_s.sum()
+                    weights = exp_s / sum_s
+
+                    acc = torch.zeros(DV, dtype=torch.float32, device=query.device)
+                    for w, (jh, jw) in zip(weights, kv_indices):
+                        acc += w * value[b, jh, jw, h_kv, :].float()
+
+                    output[b, ih, iw, h, :] = acc.to(query.dtype)
+
+    return output
+
+
+def naive_fmha_forward(query, key, value, is_causal=False, scale=None):
+    """Full self-attention reference."""
+    return naive_na1d_forward(query, key, value, query.shape[1], is_causal=is_causal, scale=scale)
+
+
+class MetalFNAForwardTest(unittest.TestCase):
+    """Forward correctness tests for Metal FNA."""
+
+    @skip_if_no_metal
+    def test_na1d_basic_fp32(self):
+        """NA1D forward, kernel_size=5, FP32."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_basic_fp16(self):
+        """NA1D forward, kernel_size=5, FP16."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=2e-3, rtol=2e-3)
+
+    @skip_if_no_metal
+    def test_na1d_basic_bf16(self):
+        """NA1D forward, kernel_size=5, BF16."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.bfloat16)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.bfloat16)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.bfloat16)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=2e-2, rtol=2e-2)
+
+    @skip_if_no_metal
+    def test_na1d_even_kernel(self):
+        """NA1D with even kernel_size=6."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=6)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=6)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_causal(self):
+        """NA1D causal forward."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5, is_causal=True)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5, is_causal=True)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_gqa(self):
+        """NA1D with GQA (heads_q=4, heads_kv=2)."""
+        torch.manual_seed(42)
+        B, S, D = 1, 16, 32
+        HQ, HKV = 4, 2
+        q = torch.randn(B, S, HQ, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_full_window(self):
+        """NA1D with kernel_size=seqlen (equivalent to full attention)."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=S)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=S)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_large_batch(self):
+        """NA1D with batch > 1."""
+        torch.manual_seed(42)
+        B, S, H, D = 4, 32, 4, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=7)
+
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=7)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+class MetalFMHAForwardTest(unittest.TestCase):
+    """Forward correctness tests for Metal FMHA."""
+
+    @skip_if_no_metal
+    def test_fmha_non_causal_fp32(self):
+        """FMHA non-causal FP32."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=False)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=False)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_fmha_causal_fp32(self):
+        """FMHA causal FP32."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=True)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=True)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_fmha_non_causal_fp16(self):
+        """FMHA non-causal FP16."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=False)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=False)
+        torch.testing.assert_close(out, ref_out, atol=2e-3, rtol=2e-3)
+
+    @skip_if_no_metal
+    def test_fmha_even_seqlen(self):
+        """FMHA with even sequence length (regression test for even kernel_size)."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 20, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=False)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=False)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_fmha_odd_seqlen(self):
+        """FMHA with odd sequence length."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 17, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=False)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=False)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_fmha_gqa(self):
+        """FMHA with GQA."""
+        torch.manual_seed(42)
+        B, S, D = 1, 16, 32
+        HQ, HKV = 4, 2
+        q = torch.randn(B, S, HQ, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fmha
+        out = metal_fmha(q, k, v, is_causal=False)
+
+        ref_out, _ = naive_fmha_forward(q, k, v, is_causal=False)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+class MetalBackwardTest(unittest.TestCase):
+    """Backward correctness tests for Metal backend."""
+
+    def _check_backward_na1d(self, B, S, H, D, kernel_size, is_causal=False,
+                              dtype=torch.float32, atol=1e-4, rtol=1e-4,
+                              heads_kv=None):
+        """Compare Metal backward against PyTorch autograd through naive reference."""
+        torch.manual_seed(42)
+        HKV = heads_kv or H
+
+        # Metal path
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=dtype, requires_grad=True)
+        k_m = torch.randn(B, S, HKV, D, device="mps", dtype=dtype, requires_grad=True)
+        v_m = torch.randn(B, S, HKV, D, device="mps", dtype=dtype, requires_grad=True)
+
+        out_m = natten.na1d(q_m, k_m, v_m, kernel_size=kernel_size, is_causal=is_causal)
+        loss_m = out_m.sum()
+        loss_m.backward()
+
+        dq_m = q_m.grad.clone()
+        dk_m = k_m.grad.clone()
+        dv_m = v_m.grad.clone()
+
+        # CPU reference path (using naive implementation + autograd)
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_na1d_forward(q_r, k_r, v_r, kernel_size=kernel_size, is_causal=is_causal)
+        loss_r = out_r.sum()
+        loss_r.backward()
+
+        dq_r = q_r.grad.to(device="mps", dtype=dtype)
+        dk_r = k_r.grad.to(device="mps", dtype=dtype)
+        dv_r = v_r.grad.to(device="mps", dtype=dtype)
+
+        torch.testing.assert_close(dq_m, dq_r, atol=atol, rtol=rtol)
+        torch.testing.assert_close(dk_m, dk_r, atol=atol, rtol=rtol)
+        torch.testing.assert_close(dv_m, dv_r, atol=atol, rtol=rtol)
+
+    @skip_if_no_metal
+    def test_backward_na1d_basic(self):
+        """NA1D backward, kernel_size=5, FP32."""
+        self._check_backward_na1d(1, 16, 2, 32, kernel_size=5)
+
+    @skip_if_no_metal
+    def test_backward_na1d_even_kernel(self):
+        """NA1D backward, kernel_size=6."""
+        self._check_backward_na1d(1, 16, 2, 32, kernel_size=6)
+
+    @skip_if_no_metal
+    def test_backward_na1d_causal(self):
+        """NA1D backward, causal."""
+        self._check_backward_na1d(1, 16, 2, 32, kernel_size=5, is_causal=True)
+
+    @skip_if_no_metal
+    def test_backward_na1d_full_window(self):
+        """NA1D backward, kernel_size=seqlen (full attention backward)."""
+        self._check_backward_na1d(1, 16, 2, 32, kernel_size=16)
+
+    @skip_if_no_metal
+    def test_backward_na1d_large(self):
+        """NA1D backward with larger dims."""
+        self._check_backward_na1d(2, 32, 4, 64, kernel_size=7)
+
+    @skip_if_no_metal
+    def test_backward_na1d_gqa(self):
+        """NA1D backward with GQA."""
+        self._check_backward_na1d(1, 16, 4, 32, kernel_size=5, heads_kv=2)
+
+    @skip_if_no_metal
+    def test_backward_fmha_non_causal(self):
+        """FMHA backward, non-causal."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        from natten.backends.metal import metal_fmha
+        out_m = metal_fmha(q_m, k_m, v_m, is_causal=False)
+        loss_m = out_m.sum()
+        loss_m.backward()
+
+        dq_m = q_m.grad.clone()
+        dk_m = k_m.grad.clone()
+        dv_m = v_m.grad.clone()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_fmha_forward(q_r, k_r, v_r, is_causal=False)
+        loss_r = out_r.sum()
+        loss_r.backward()
+
+        dq_r = q_r.grad.to(device="mps")
+        dk_r = k_r.grad.to(device="mps")
+        dv_r = v_r.grad.to(device="mps")
+
+        torch.testing.assert_close(dq_m, dq_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dk_m, dk_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dv_m, dv_r, atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_backward_fmha_causal(self):
+        """FMHA backward, causal."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        from natten.backends.metal import metal_fmha
+        out_m = metal_fmha(q_m, k_m, v_m, is_causal=True)
+        loss_m = out_m.sum()
+        loss_m.backward()
+
+        dq_m = q_m.grad.clone()
+        dk_m = k_m.grad.clone()
+        dv_m = v_m.grad.clone()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_fmha_forward(q_r, k_r, v_r, is_causal=True)
+        loss_r = out_r.sum()
+        loss_r.backward()
+
+        dq_r = q_r.grad.to(device="mps")
+        dk_r = k_r.grad.to(device="mps")
+        dv_r = v_r.grad.to(device="mps")
+
+        torch.testing.assert_close(dq_m, dq_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dk_m, dk_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dv_m, dv_r, atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_backward_fmha_even_seqlen(self):
+        """FMHA backward with even seqlen (regression for even kernel_size bug)."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 20, 2, 32
+
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        from natten.backends.metal import metal_fmha
+        out_m = metal_fmha(q_m, k_m, v_m, is_causal=False)
+        loss_m = out_m.sum()
+        loss_m.backward()
+
+        dq_m = q_m.grad.clone()
+        dk_m = k_m.grad.clone()
+        dv_m = v_m.grad.clone()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_fmha_forward(q_r, k_r, v_r, is_causal=False)
+        loss_r = out_r.sum()
+        loss_r.backward()
+
+        dq_r = q_r.grad.to(device="mps")
+        dk_r = k_r.grad.to(device="mps")
+        dv_r = v_r.grad.to(device="mps")
+
+        torch.testing.assert_close(dq_m, dq_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dk_m, dk_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(dv_m, dv_r, atol=1e-4, rtol=1e-4)
+
+
+class MetalNA2DTest(unittest.TestCase):
+    """Forward and backward tests for NA2D."""
+
+    @skip_if_no_metal
+    def test_na2d_forward_fp32(self):
+        """NA2D forward with full window (should match full attention)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 4, 4, 2, 32
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        # Full window = full attention
+        out_full = natten.na2d(q, k, v, kernel_size=(Hsp, Wsp))
+
+        # Compare with flattened FMHA
+        from natten.backends.metal import metal_fmha
+        S = Hsp * Wsp
+        q_flat = q.reshape(B, S, H, D)
+        k_flat = k.reshape(B, S, H, D)
+        v_flat = v.reshape(B, S, H, D)
+        out_fmha = metal_fmha(q_flat, k_flat, v_flat, is_causal=False)
+        out_fmha = out_fmha.reshape(B, Hsp, Wsp, H, D)
+
+        torch.testing.assert_close(out_full, out_fmha, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na2d_forward_small_window(self):
+        """NA2D forward with kernel_size=(3,3) — compare against naive 2D reference."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 8, 8, 2, 32
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(3, 3))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(3, 3))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na2d_backward(self):
+        """NA2D backward with full window — compare against FMHA backward."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 4, 4, 2, 32
+        S = Hsp * Wsp
+
+        # Metal NA2D path (full window = full attention)
+        q_2d = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_2d = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_2d = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_2d = natten.na2d(q_2d, k_2d, v_2d, kernel_size=(Hsp, Wsp))
+        out_2d.sum().backward()
+
+        # Reference: CPU naive FMHA on flattened tensors
+        q_r = q_2d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+        k_r = k_2d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+        v_r = v_2d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_fmha_forward(q_r, k_r, v_r, is_causal=False)
+        out_r.sum().backward()
+
+        torch.testing.assert_close(q_2d.grad, q_r.grad.reshape(B, Hsp, Wsp, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_2d.grad, k_r.grad.reshape(B, Hsp, Wsp, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_2d.grad, v_r.grad.reshape(B, Hsp, Wsp, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na2d_backward_small_window(self):
+        """NA2D backward with small kernel_size=(3,3) — compare against naive 2D reference autograd."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 6, 6, 2, 32
+        ks = (3, 3)
+
+        # Metal NA2D path
+        q_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_m = natten.na2d(q_m, k_m, v_m, kernel_size=ks)
+        out_m.sum().backward()
+
+        # CPU naive 2D reference
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out = naive_na2d_forward(q_r, k_r, v_r, kernel_size=ks)
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na2d_forward_causal(self):
+        """NA2D forward with causal=(True, True)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 8, 8, 2, 32
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(5, 5), is_causal=(True, True))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(5, 5), is_causal=(True, True))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na2d_backward_causal(self):
+        """NA2D backward with causal=(True, True)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 6, 6, 2, 32
+        ks = (5, 5)
+
+        q_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_m = natten.na2d(q_m, k_m, v_m, kernel_size=ks, is_causal=(True, True))
+        out_m.sum().backward()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out = naive_na2d_forward(q_r, k_r, v_r, kernel_size=ks, is_causal=(True, True))
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na2d_forward_gqa(self):
+        """NA2D forward with GQA (heads_q=4, heads_kv=2)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, D = 1, 8, 8, 32
+        HQ, HKV = 4, 2
+        q = torch.randn(B, Hsp, Wsp, HQ, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, HKV, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, HKV, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(3, 3))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(3, 3))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na2d_backward_gqa(self):
+        """NA2D backward with GQA (heads_q=4, heads_kv=2)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, D = 1, 6, 6, 32
+        HQ, HKV = 4, 2
+
+        q_m = torch.randn(B, Hsp, Wsp, HQ, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, Hsp, Wsp, HKV, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, Hsp, Wsp, HKV, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_m = natten.na2d(q_m, k_m, v_m, kernel_size=(3, 3))
+        out_m.sum().backward()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out = naive_na2d_forward(q_r, k_r, v_r, kernel_size=(3, 3))
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na2d_forward_stride(self):
+        """NA2D forward with stride=(2,2)."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 8, 8, 2, 32
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(3, 3), stride=(2, 2))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(3, 3), stride=(2, 2))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+class MetalNA3DTest(unittest.TestCase):
+    """Forward and backward tests for NA3D."""
+
+    @skip_if_no_metal
+    def test_na3d_forward_fp32(self):
+        """NA3D forward with full window."""
+        torch.manual_seed(42)
+        B, D1, D2, D3, H, D = 1, 3, 3, 3, 2, 32
+        q = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+
+        # Full window = full attention
+        out_full = natten.na3d(q, k, v, kernel_size=(D1, D2, D3))
+
+        from natten.backends.metal import metal_fmha
+        S = D1 * D2 * D3
+        q_flat = q.reshape(B, S, H, D)
+        k_flat = k.reshape(B, S, H, D)
+        v_flat = v.reshape(B, S, H, D)
+        out_fmha = metal_fmha(q_flat, k_flat, v_flat, is_causal=False)
+        out_fmha = out_fmha.reshape(B, D1, D2, D3, H, D)
+
+        torch.testing.assert_close(out_full, out_fmha, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na3d_forward_small_window(self):
+        """NA3D forward with small kernel_size=(3,3,3) — exercises actual neighborhood masking."""
+        torch.manual_seed(42)
+        B, D1, D2, D3, H, D = 1, 5, 5, 5, 2, 32
+        q = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32)
+
+        out_small = natten.na3d(q, k, v, kernel_size=(3, 3, 3))
+        out_full = natten.na3d(q, k, v, kernel_size=(D1, D2, D3))
+
+        # Small window should NOT match full window (neighborhood masking is active)
+        self.assertFalse(torch.allclose(out_small, out_full, atol=1e-5))
+
+        # Verify shape
+        self.assertEqual(out_small.shape, (B, D1, D2, D3, H, D))
+
+    @skip_if_no_metal
+    def test_na3d_backward(self):
+        """NA3D backward with full window — compare against FMHA backward."""
+        torch.manual_seed(42)
+        B, D1, D2, D3, H, D = 1, 3, 3, 3, 2, 32
+        S = D1 * D2 * D3
+
+        q_3d = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_3d = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_3d = torch.randn(B, D1, D2, D3, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_3d = natten.na3d(q_3d, k_3d, v_3d, kernel_size=(D1, D2, D3))
+        out_3d.sum().backward()
+
+        # Reference: CPU naive FMHA on flattened tensors
+        q_r = q_3d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+        k_r = k_3d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+        v_r = v_3d.detach().reshape(B, S, H, D).cpu().float().requires_grad_(True)
+
+        out_r, _ = naive_fmha_forward(q_r, k_r, v_r, is_causal=False)
+        out_r.sum().backward()
+
+        torch.testing.assert_close(q_3d.grad, q_r.grad.reshape(B, D1, D2, D3, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_3d.grad, k_r.grad.reshape(B, D1, D2, D3, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_3d.grad, v_r.grad.reshape(B, D1, D2, D3, H, D).to("mps"), atol=1e-4, rtol=1e-4)
+
+
+class MetalStrideAndDilationTest(unittest.TestCase):
+    """Tests for stride > 1 and dilation > 1."""
+
+    @skip_if_no_metal
+    def test_na1d_stride(self):
+        """NA1D forward with stride=2 — compare against naive reference."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5, stride=2)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5, stride=2)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_dilation(self):
+        """NA1D forward with dilation=2 — compare against naive reference."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5, dilation=2)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5, dilation=2)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_na1d_stride_backward(self):
+        """NA1D backward with stride=2 — compare against naive reference autograd."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_m = natten.na1d(q_m, k_m, v_m, kernel_size=5, stride=2)
+        out_m.sum().backward()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out, _ = naive_na1d_forward(q_r, k_r, v_r, kernel_size=5, stride=2)
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na1d_dilation_backward(self):
+        """NA1D backward with dilation=2 — compare against naive reference autograd."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+
+        q_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v_m = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out_m = natten.na1d(q_m, k_m, v_m, kernel_size=5, dilation=2)
+        out_m.sum().backward()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out, _ = naive_na1d_forward(q_r, k_r, v_r, kernel_size=5, dilation=2)
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+    @skip_if_no_metal
+    def test_na2d_dilation(self):
+        """NA2D forward with dilation=(2,2) — compare against naive 2D reference."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 8, 8, 2, 32
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(3, 3), dilation=(2, 2))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(3, 3), dilation=(2, 2))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+class MetalAdditionalKVTest(unittest.TestCase):
+    """Tests for additional KV tokens (cross-attention)."""
+
+    @skip_if_no_metal
+    def test_na1d_additional_kv_forward(self):
+        """NA1D forward with additional_keys/values."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        num_extra = 4
+
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        ak = torch.randn(B, num_extra, H, D, device="mps", dtype=torch.float32)
+        av = torch.randn(B, num_extra, H, D, device="mps", dtype=torch.float32)
+
+        from natten.backends.metal import metal_fna_generic
+        out = metal_fna_generic(
+            q, k, v,
+            kernel_size=5,
+            additional_keys=ak,
+            additional_values=av,
+        )
+        assert out.shape == (B, S, H, D)
+
+    @skip_if_no_metal
+    def test_na1d_additional_kv_backward(self):
+        """NA1D backward with additional_keys/values — determinism + non-zero + gradient flow."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 32
+        num_extra = 4
+
+        q1 = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k1 = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v1 = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        ak1 = torch.randn(B, num_extra, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        av1 = torch.randn(B, num_extra, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        from natten.backends.metal import metal_fna_generic
+        out1 = metal_fna_generic(q1, k1, v1, kernel_size=5, additional_keys=ak1, additional_values=av1)
+        out1.sum().backward()
+
+        # Second run with same data
+        q2 = q1.detach().clone().requires_grad_(True)
+        k2 = k1.detach().clone().requires_grad_(True)
+        v2 = v1.detach().clone().requires_grad_(True)
+        ak2 = ak1.detach().clone().requires_grad_(True)
+        av2 = av1.detach().clone().requires_grad_(True)
+
+        out2 = metal_fna_generic(q2, k2, v2, kernel_size=5, additional_keys=ak2, additional_values=av2)
+        out2.sum().backward()
+
+        # Determinism
+        torch.testing.assert_close(q1.grad, q2.grad, atol=0, rtol=0)
+        torch.testing.assert_close(k1.grad, k2.grad, atol=0, rtol=0)
+        torch.testing.assert_close(v1.grad, v2.grad, atol=0, rtol=0)
+        torch.testing.assert_close(ak1.grad, ak2.grad, atol=0, rtol=0)
+        torch.testing.assert_close(av1.grad, av2.grad, atol=0, rtol=0)
+
+        # Non-trivial gradients (all 5 tensors should receive gradient flow)
+        assert q1.grad.abs().sum() > 0
+        assert k1.grad.abs().sum() > 0
+        assert v1.grad.abs().sum() > 0
+        assert ak1.grad.abs().sum() > 0, "additional_keys should receive gradients"
+        assert av1.grad.abs().sum() > 0, "additional_values should receive gradients"
+
+        # Verify shapes
+        assert q1.grad.shape == q1.shape
+        assert ak1.grad.shape == ak1.shape
+        assert av1.grad.shape == av1.shape
+
+
+class MetalSmokeTest(unittest.TestCase):
+    """Quick integration smoke tests."""
+
+    @skip_if_no_metal
+    def test_na1d_forward_backward_smoke(self):
+        """End-to-end: na1d forward + backward on MPS."""
+        q = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        k = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        v = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        out = natten.na1d(q, k, v, kernel_size=5)
+        out.sum().backward()
+        self.assertEqual(q.grad.shape, q.shape)
+        self.assertEqual(k.grad.shape, k.shape)
+        self.assertEqual(v.grad.shape, v.shape)
+
+    @skip_if_no_metal
+    def test_fmha_forward_backward_smoke(self):
+        """End-to-end: FMHA forward + backward on MPS."""
+        from natten.backends.metal import metal_fmha
+        q = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        k = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        v = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        out = metal_fmha(q, k, v)
+        out.sum().backward()
+        self.assertEqual(q.grad.shape, q.shape)
+        self.assertEqual(k.grad.shape, k.shape)
+        self.assertEqual(v.grad.shape, v.shape)
+
+    @skip_if_no_metal
+    def test_requires_grad_accepted(self):
+        """Verify that requires_grad=True tensors are accepted by Metal backend."""
+        from natten.backends.configs.checks import can_run_metal_fna, can_run_metal_fmha
+        q = torch.randn(1, 16, 4, 64, device="mps", requires_grad=True)
+        k = torch.randn(1, 16, 4, 64, device="mps")
+        v = torch.randn(1, 16, 4, 64, device="mps")
+        self.assertTrue(can_run_metal_fna(q, k, v))
+        self.assertTrue(can_run_metal_fmha(q, k, v, is_causal=False, is_varlen=False))
+
+
+class MetalTiledForwardTest(unittest.TestCase):
+    """Tests that the tiled flash-attention forward kernel matches the naive reference.
+    The tiled kernel is used for D<=128; these tests cover NA1D, NA2D, various kernel sizes,
+    D=32, D=64, and D=128, plus FP16 and causal modes.
+    """
+
+    @skip_if_no_metal
+    def test_tiled_na1d_d32_ks5(self):
+        """NA1D D=32, kernel_size=5 — exercises Br=32 path."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 4, 32
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_d64_ks7(self):
+        """NA1D D=64, kernel_size=7 — exercises Br=32 path."""
+        torch.manual_seed(42)
+        B, S, H, D = 2, 128, 4, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=7)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=7)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_d128_ks5(self):
+        """NA1D D=128, kernel_size=5 — exercises Br=16 path."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 4, 128
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_full_window(self):
+        """NA1D with kernel_size=seqlen (full attention) via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=S)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=S)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_even_kernel(self):
+        """NA1D with even kernel_size=6 via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=6)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=6)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_causal(self):
+        """NA1D causal via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=7, is_causal=True)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=7, is_causal=True)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_fp16(self):
+        """NA1D FP16 via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float16)
+
+        out = natten.na1d(q, k, v, kernel_size=7)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=7)
+        torch.testing.assert_close(out, ref_out, atol=2e-3, rtol=2e-3)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_gqa(self):
+        """NA1D with GQA via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, D = 1, 64, 64
+        HQ, HKV = 8, 2
+        q = torch.randn(B, S, HQ, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, HKV, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=7)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=7)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na2d_small_window(self):
+        """NA2D k=(3,3) via tiled kernel — the main performance target."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 16, 16, 2, 64
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(3, 3))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(3, 3))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na2d_k13(self):
+        """NA2D k=(13,13) — the benchmark scenario from the plan."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 16, 16, 2, 64
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(13, 13))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(13, 13))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na2d_full_window(self):
+        """NA2D full window via tiled kernel."""
+        torch.manual_seed(42)
+        B, Hsp, Wsp, H, D = 1, 8, 8, 2, 64
+        q = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, Hsp, Wsp, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na2d(q, k, v, kernel_size=(Hsp, Wsp))
+        ref_out = naive_na2d_forward(q, k, v, kernel_size=(Hsp, Wsp))
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_dilation(self):
+        """NA1D with dilation=2 via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5, dilation=2)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5, dilation=2)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+    @skip_if_no_metal
+    def test_tiled_na1d_stride(self):
+        """NA1D with stride=2 via tiled kernel."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 64, 2, 64
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32)
+
+        out = natten.na1d(q, k, v, kernel_size=5, stride=2)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5, stride=2)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+class MetalTiledBackwardTest(unittest.TestCase):
+    """Tests for tiled backward kernels (flash-attention style)."""
+
+    def _compare_backward(self, B, S, H, D, KS, dtype=torch.float32,
+                          is_causal=False, heads_kv=None, atol=1e-4, rtol=1e-3):
+        """Run metal backward and compare against naive reference backward."""
+        torch.manual_seed(42)
+        HKV = heads_kv or H
+        q = torch.randn(B, S, H, D, device="mps", dtype=dtype, requires_grad=True)
+        k = torch.randn(B, S, HKV, D, device="mps", dtype=dtype, requires_grad=True)
+        v = torch.randn(B, S, HKV, D, device="mps", dtype=dtype, requires_grad=True)
+
+        # Metal backward
+        o = natten.na1d(q, k, v, kernel_size=KS, is_causal=is_causal)
+        o.sum().backward()
+        torch.mps.synchronize()
+        dq_m, dk_m, dv_m = q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+        # Naive reference backward via autograd
+        q2 = q.detach().clone().requires_grad_(True)
+        k2 = k.detach().clone().requires_grad_(True)
+        v2 = v.detach().clone().requires_grad_(True)
+        ref_out, _ = naive_na1d_forward(q2, k2, v2, kernel_size=KS, is_causal=is_causal)
+        ref_out.sum().backward()
+        torch.mps.synchronize()
+
+        torch.testing.assert_close(dq_m.float(), q2.grad.float(), atol=atol, rtol=rtol)
+        torch.testing.assert_close(dk_m.float(), k2.grad.float(), atol=atol, rtol=rtol)
+        torch.testing.assert_close(dv_m.float(), v2.grad.float(), atol=atol, rtol=rtol)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_d32_ks5(self):
+        self._compare_backward(1, 32, 2, 32, 5)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_d64_ks7(self):
+        self._compare_backward(1, 64, 2, 64, 7)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_d128_ks5(self):
+        self._compare_backward(1, 32, 2, 128, 5)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_even_kernel(self):
+        self._compare_backward(1, 32, 2, 32, 6)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_full_window(self):
+        """FMHA case: kernel_size = seqlen."""
+        self._compare_backward(1, 16, 2, 32, 16)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_causal(self):
+        self._compare_backward(1, 32, 2, 32, 7, is_causal=True)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_gqa(self):
+        self._compare_backward(1, 32, 4, 32, 5, heads_kv=2)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_fp16(self):
+        self._compare_backward(1, 32, 2, 64, 5, dtype=torch.float16, atol=5e-2, rtol=5e-2)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_bf16(self):
+        """Backward with BF16."""
+        self._compare_backward(1, 32, 2, 32, 5, dtype=torch.bfloat16, atol=5e-2, rtol=5e-2)
+
+    @skip_if_no_metal
+    def test_tiled_bwd_na2d(self):
+        """NA2D backward — numerical correctness against naive 2D reference."""
+        torch.manual_seed(42)
+        B, Sx, Sy, H, D = 1, 8, 8, 2, 32
+        ks = (5, 5)
+
+        q_m = torch.randn(B, Sx, Sy, H, D, device="mps", requires_grad=True)
+        k_m = torch.randn(B, Sx, Sy, H, D, device="mps", requires_grad=True)
+        v_m = torch.randn(B, Sx, Sy, H, D, device="mps", requires_grad=True)
+
+        out_m = natten.na2d(q_m, k_m, v_m, kernel_size=ks)
+        out_m.sum().backward()
+        torch.mps.synchronize()
+
+        q_r = q_m.detach().cpu().float().requires_grad_(True)
+        k_r = k_m.detach().cpu().float().requires_grad_(True)
+        v_r = v_m.detach().cpu().float().requires_grad_(True)
+
+        ref_out = naive_na2d_forward(q_r, k_r, v_r, kernel_size=ks)
+        ref_out.sum().backward()
+
+        torch.testing.assert_close(q_m.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-3)
+        torch.testing.assert_close(k_m.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-3)
+        torch.testing.assert_close(v_m.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-3)
+
+    @skip_if_no_metal
+    def test_reference_fallback_d256(self):
+        """D=256 falls back to reference kernel (tiled only supports D<=128)."""
+        torch.manual_seed(42)
+        B, S, H, D = 1, 16, 2, 256
+        q = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        k = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+        v = torch.randn(B, S, H, D, device="mps", dtype=torch.float32, requires_grad=True)
+
+        out = natten.na1d(q, k, v, kernel_size=5)
+        ref_out, _ = naive_na1d_forward(q, k, v, kernel_size=5)
+        torch.testing.assert_close(out, ref_out, atol=1e-5, rtol=1e-5)
+
+        out.sum().backward()
+        torch.mps.synchronize()
+
+        q_r = q.detach().cpu().float().requires_grad_(True)
+        k_r = k.detach().cpu().float().requires_grad_(True)
+        v_r = v.detach().cpu().float().requires_grad_(True)
+        ref_out2, _ = naive_na1d_forward(q_r, k_r, v_r, kernel_size=5)
+        ref_out2.sum().backward()
+
+        torch.testing.assert_close(q.grad, q_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(k.grad, k_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(v.grad, v_r.grad.to("mps"), atol=1e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Metal backend for NA1D/2D/3D on Apple Silicon (MPS devices).

Tiled flash-attention forward and backward kernels supporting FP32/FP16/BF16, GQA, causal masking, stride, dilation, and additional KV tokens.

Backend is auto-selected when tensors are on MPS