### PR TITLE
cutlass-fna: 64b strides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Main branch]
+* Switched to int64 strides in cutlass-fna to avoid overflows in larger use cases.
 
 ## [0.21.6] - 2026-04-14
 * Fixed syntax error in natten.profiler (only affects `python < 3.12`)

--- a/csrc/include/natten/cuda/fna/epilogue/predicated_tile_iterator.h
+++ b/csrc/include/natten/cuda/fna/epilogue/predicated_tile_iterator.h
@@ -84,6 +84,7 @@ class CustomPredicatedTileIterator {
  public:
   static_assert(NADim >= 1 && NADim < 4);
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using ThreadMap = ThreadMap_;
   using Shape = typename ThreadMap::Shape;
@@ -138,7 +139,7 @@ class CustomPredicatedTileIterator {
     Params() {}
 
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : ParamsBase(
               stride,
               int32_t(sizeof(AccessType)) / kElementsPerAccess,

--- a/csrc/include/natten/cuda/fna/epilogue/predicated_tile_iterator_params.h
+++ b/csrc/include/natten/cuda/fna/epilogue/predicated_tile_iterator_params.h
@@ -58,6 +58,7 @@ namespace threadblock {
 template <int NADim>
 struct CustomPredicatedTileIteratorParams {
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Index = int32_t;
   using LongIndex = int64_t;
@@ -66,7 +67,8 @@ struct CustomPredicatedTileIteratorParams {
   // Data members
   //
 
-  Dim stride; ///< stride in bytes between rows
+  Stride stride; ///< stride in bytes between rows (int64-typed so stride*coord
+                 ///< doesn't overflow int32)
 
   // LongIndex increment_row;        ///< increment quantity (in bytes) to
   // advance when moving between rows LongIndex increment_group;      ///<
@@ -86,7 +88,7 @@ struct CustomPredicatedTileIteratorParams {
 
   CUTLASS_HOST_DEVICE
   Status initialize(
-      Dim stride_,
+      Stride stride_,
       Index elem,
       Dim extent_row,
       OutputTileThreadMapDesc thread_map) {
@@ -137,7 +139,7 @@ struct CustomPredicatedTileIteratorParams {
 
   CUTLASS_HOST_DEVICE
   CustomPredicatedTileIteratorParams(
-      Dim stride,
+      Stride stride,
       Index elem,
       Dim extent_row,
       OutputTileThreadMapDesc thread_map) {

--- a/csrc/include/natten/cuda/fna/iterators/epilogue_predicated_tile_iterator.h
+++ b/csrc/include/natten/cuda/fna/iterators/epilogue_predicated_tile_iterator.h
@@ -87,6 +87,7 @@ class PredicatedTileIteratorPrefetch {
  public:
   static_assert(NADim >= 1 && NADim < 4);
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using ThreadMap = ThreadMap_;
   using Shape = typename ThreadMap::Shape;
@@ -141,7 +142,7 @@ class PredicatedTileIteratorPrefetch {
     Params() {}
 
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : ParamsBase(
               stride,
               int32_t(sizeof(AccessType)) / kElementsPerAccess,

--- a/csrc/include/natten/cuda/fna/iterators/predicated_tile_access_iterator.h
+++ b/csrc/include/natten/cuda/fna/iterators/predicated_tile_access_iterator.h
@@ -72,6 +72,7 @@ namespace threadblock {
 template <int NADim, typename Shape>
 struct CustomPredicatedTileAccessIteratorParams {
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Index = int32_t;
   using LongIndex =
@@ -81,7 +82,7 @@ struct CustomPredicatedTileAccessIteratorParams {
   // Data members
   //
   /// stride of pitch-linear layout (units of Element)
-  Dim stride_;
+  Stride stride_;
   /// amount (in byte) to increment pointer to move to next access along
   /// strided dimension
   LongIndex inc_strided_;
@@ -98,7 +99,7 @@ struct CustomPredicatedTileAccessIteratorParams {
 
   CUTLASS_HOST_DEVICE
   Status initialize(
-      Dim stride,
+      Stride stride,
       Dim extent_row,
       PredicatedTileAccessIteratorDesc desc) {
     stride_ = stride;
@@ -173,7 +174,7 @@ struct CustomPredicatedTileAccessIteratorParams {
 
   CUTLASS_HOST_DEVICE
   CustomPredicatedTileAccessIteratorParams(
-      Dim stride,
+      Stride stride,
       Dim extent_row,
       PredicatedTileAccessIteratorDesc desc) {
     initialize(stride, extent_row, desc);
@@ -196,6 +197,7 @@ class CustomPredicatedTileAccessIteratorPredicates {
  public:
   static_assert(NADim >= 1 && NADim < 4);
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -534,6 +536,7 @@ class CustomPredicatedTileAccessIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -579,7 +582,7 @@ class CustomPredicatedTileAccessIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : Base(
               stride,
               extent_row,
@@ -909,6 +912,7 @@ class CustomPredicatedTileAccessIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -954,7 +958,7 @@ class CustomPredicatedTileAccessIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : Base(
               stride,
               extent_row,
@@ -1241,6 +1245,7 @@ class CustomPredicatedTileAccessIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -1287,7 +1292,7 @@ class CustomPredicatedTileAccessIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row){};
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row){};
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
@@ -1464,6 +1469,7 @@ class CustomPredicatedTileAccessIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -1510,7 +1516,7 @@ class CustomPredicatedTileAccessIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row){};
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row){};
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE

--- a/csrc/include/natten/cuda/fna/iterators/predicated_tile_access_iterator_residual_last.h
+++ b/csrc/include/natten/cuda/fna/iterators/predicated_tile_access_iterator_residual_last.h
@@ -115,6 +115,7 @@ class PredicatedTileAccessIteratorResidualLast<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -161,7 +162,7 @@ class PredicatedTileAccessIteratorResidualLast<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : Base(
               stride,
               extent_row,
@@ -462,6 +463,7 @@ class PredicatedTileAccessIteratorResidualLast<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -508,7 +510,7 @@ class PredicatedTileAccessIteratorResidualLast<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row)
+    Params(Stride stride, Dim extent_row)
         : Base(
               stride,
               extent_row,
@@ -775,6 +777,7 @@ class PredicatedTileAccessIteratorResidualLast<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -822,7 +825,7 @@ class PredicatedTileAccessIteratorResidualLast<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row){};
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row){};
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE

--- a/csrc/include/natten/cuda/fna/iterators/predicated_tile_iterator.h
+++ b/csrc/include/natten/cuda/fna/iterators/predicated_tile_iterator.h
@@ -94,6 +94,7 @@ class CustomPredicatedTileIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -151,7 +152,7 @@ class CustomPredicatedTileIterator<
    public:
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row) {}
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row) {}
 
     /// Default constructor
     Params() = default;
@@ -392,6 +393,7 @@ class CustomPredicatedTileIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -442,7 +444,7 @@ class CustomPredicatedTileIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row) {}
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row) {}
 
     CUTLASS_HOST_DEVICE
     Params(typename UnderlyingIterator::Params::Base const& base)
@@ -623,6 +625,7 @@ class CustomPredicatedTileIterator<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -673,7 +676,7 @@ class CustomPredicatedTileIterator<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row) {}
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row) {}
 
     CUTLASS_HOST_DEVICE
     Params(typename UnderlyingIterator::Params::Base const& base)

--- a/csrc/include/natten/cuda/fna/iterators/predicated_tile_iterator_residual_last.h
+++ b/csrc/include/natten/cuda/fna/iterators/predicated_tile_iterator_residual_last.h
@@ -107,6 +107,7 @@ class PredicatedTileIteratorResidualLast<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -164,7 +165,7 @@ class PredicatedTileIteratorResidualLast<
    public:
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row) {}
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row) {}
 
     CUTLASS_HOST_DEVICE
     Params() {}
@@ -408,6 +409,7 @@ class PredicatedTileIteratorResidualLast<
       "contiguous(rank=0) or strided(rank=1) dimension.");
 
   using Dim = typename natten::cuda::fna::GetDim<NADim>::type;
+  using Stride = typename natten::cuda::fna::GetStride<NADim>::type;
 
   using Shape = Shape_;
   using Element = Element_;
@@ -458,7 +460,7 @@ class PredicatedTileIteratorResidualLast<
 
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
-    Params(Dim stride, Dim extent_row) : params_(stride, extent_row) {}
+    Params(Stride stride, Dim extent_row) : params_(stride, extent_row) {}
 
     CUTLASS_HOST_DEVICE
     Params(typename UnderlyingIterator::Params::Base const& base)

--- a/csrc/include/natten/cuda/fna/kernel_backward.h
+++ b/csrc/include/natten/cuda/fna/kernel_backward.h
@@ -239,6 +239,7 @@ struct FusedNeighborhoodAttentionBackwardKernel {
   static constexpr int NADim = NADim_;
   static_assert(NADim >= 1 && NADim < 4, "Only 1D-3D NA are implemented.");
   using Dim = typename GetDim<NADim>::type;
+  using Stride = typename GetStride<NADim>::type;
   using NAMask = NeighborhoodAttentionMask<NADim, CausalMask>;
   static constexpr bool kHasCausalDims = CausalMask::AnyCausalDims;
 
@@ -702,11 +703,11 @@ struct FusedNeighborhoodAttentionBackwardKernel {
     int32_t num_heads = -1;
     int32_t num_batches = -1;
 
-    Dim lse_strideM;
-    Dim q_strideM;
-    Dim k_strideM;
-    Dim v_strideM;
-    Dim o_strideM;
+    Stride lse_strideM;
+    Stride q_strideM;
+    Stride k_strideM;
+    Stride v_strideM;
+    Stride o_strideM;
 
     // int16_t num_splits_key = 1; // We use `gridDim.x` inside kernel
     Dim num_splits_key; // We use `gridDim.x` inside kernel

--- a/csrc/include/natten/cuda/fna/kernel_forward.h
+++ b/csrc/include/natten/cuda/fna/kernel_forward.h
@@ -116,6 +116,7 @@ struct FusedNeighborhoodAttentionKernel {
   static constexpr int NADim = NADim_;
   static_assert(NADim >= 1 && NADim < 4, "Only 1D-3D NA are implemented.");
   using Dim = typename GetDim<NADim>::type;
+  using Stride = typename GetStride<NADim>::type;
   using NAMask = NeighborhoodAttentionMask<NADim, CausalMask>;
 
   static constexpr int kKeysPerBlock = kKeysPerBlock_;
@@ -188,11 +189,11 @@ struct FusedNeighborhoodAttentionKernel {
     Dim query_tile_shape;
     Dim key_tile_shape;
 
-    Dim lse_strideM;
-    Dim q_strideM;
-    Dim k_strideM;
-    Dim v_strideM;
-    Dim o_strideM;
+    Stride lse_strideM;
+    Stride q_strideM;
+    Stride k_strideM;
+    Stride v_strideM;
+    Stride o_strideM;
 
     int32_t num_heads = 0;
     int32_t num_batches = 0;

--- a/csrc/include/natten/cuda/fna/na_utils.cuh
+++ b/csrc/include/natten/cuda/fna/na_utils.cuh
@@ -33,53 +33,102 @@
 
 #include <natten/cuda/fna/gemm_kernel_utils.h>
 
+#include <type_traits>
+
 namespace natten {
 namespace cuda {
 namespace fna {
 
-struct NA1dDim {
-  int32_t x;
+// NA{1,2,3}dDimT<T> is parameterized on the integer element type so the same
+// struct serves as both the int32 coord/extent and the int64 byte-stride. The
+// public aliases below preserve the existing names:
+//     NA{1,2,3}dDim    = NA{1,2,3}dDimT<int32_t>
+//     NA{1,2,3}dStride = NA{1,2,3}dDimT<int64_t>
+// The cross-T operator overloads promote the result to common_type<T,U>, so
+// (Dim * Stride).sum() and (Stride * Dim).sum() are computed in int64 and
+// don't overflow int32 when stride * coord exceeds 2**31-1.
+
+template <typename T>
+struct NA1dDimT {
+  T x;
 
   // Default ctor
-  CUTLASS_HOST_DEVICE constexpr NA1dDim(int32_t x_) : x(x_) {}
+  CUTLASS_HOST_DEVICE constexpr NA1dDimT(T x_) : x(x_) {}
 
-  CUTLASS_HOST_DEVICE NA1dDim() : x(0) {}
+  CUTLASS_HOST_DEVICE NA1dDimT() : x(0) {}
 
-  CUTLASS_HOST_DEVICE void operator=(const NA1dDim& other) {
+  CUTLASS_HOST_DEVICE void operator=(const NA1dDimT& other) {
     x = other.x;
   }
 
   // Operators
-  CUTLASS_HOST_DEVICE NA1dDim operator+(NA1dDim other) const {
-    return NA1dDim(x + other.x);
+  CUTLASS_HOST_DEVICE NA1dDimT operator+(NA1dDimT other) const {
+    return NA1dDimT(x + other.x);
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator*(NA1dDim other) const {
-    return NA1dDim(x * other.x);
+  CUTLASS_HOST_DEVICE NA1dDimT operator*(NA1dDimT other) const {
+    return NA1dDimT(x * other.x);
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator-(NA1dDim other) const {
-    return NA1dDim(x - other.x);
+  CUTLASS_HOST_DEVICE NA1dDimT operator-(NA1dDimT other) const {
+    return NA1dDimT(x - other.x);
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator/(NA1dDim other) const {
-    return NA1dDim(x / other.x);
+  CUTLASS_HOST_DEVICE NA1dDimT operator/(NA1dDimT other) const {
+    return NA1dDimT(x / other.x);
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator+(int32_t other) const {
-    return NA1dDim(x + other);
+  // Cross-T binary ops; promote to common_type<T, U>.
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA1dDimT<typename std::common_type<T, U>::type> operator+(
+      NA1dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA1dDimT<R>(static_cast<R>(x) + static_cast<R>(other.x));
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator*(int32_t other) const {
-    return NA1dDim(x * other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA1dDimT<typename std::common_type<T, U>::type> operator*(
+      NA1dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA1dDimT<R>(static_cast<R>(x) * static_cast<R>(other.x));
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator-(int32_t other) const {
-    return NA1dDim(x - other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA1dDimT<typename std::common_type<T, U>::type> operator-(
+      NA1dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA1dDimT<R>(static_cast<R>(x) - static_cast<R>(other.x));
   }
 
-  CUTLASS_HOST_DEVICE NA1dDim operator/(int32_t other) const {
-    return NA1dDim(x / other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA1dDimT<typename std::common_type<T, U>::type> operator/(
+      NA1dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA1dDimT<R>(static_cast<R>(x) / static_cast<R>(other.x));
+  }
+
+  CUTLASS_HOST_DEVICE NA1dDimT operator+(int32_t other) const {
+    return NA1dDimT(x + other);
+  }
+
+  CUTLASS_HOST_DEVICE NA1dDimT operator*(int32_t other) const {
+    return NA1dDimT(x * other);
+  }
+
+  CUTLASS_HOST_DEVICE NA1dDimT operator-(int32_t other) const {
+    return NA1dDimT(x - other);
+  }
+
+  CUTLASS_HOST_DEVICE NA1dDimT operator/(int32_t other) const {
+    return NA1dDimT(x / other);
   }
 
   // Cmp
@@ -99,7 +148,7 @@ struct NA1dDim {
   //   return x >= other.x;
   // }
 
-  CUTLASS_HOST_DEVICE bool operator==(NA1dDim other) const {
+  CUTLASS_HOST_DEVICE bool operator==(NA1dDimT other) const {
     return x == other.x;
   }
 
@@ -107,8 +156,8 @@ struct NA1dDim {
   // coordinate exceeds the spatial extent. This is used in
   // the NA mask (`get_window_start`).
   // It should NOT overload the >= operator.
-  CUTLASS_HOST_DEVICE NA1dDim is_overflowing(NA1dDim extent) const {
-    return NA1dDim(x >= extent.x);
+  CUTLASS_HOST_DEVICE NA1dDimT is_overflowing(NA1dDimT extent) const {
+    return NA1dDimT(x >= extent.x);
   }
 
   // CUTLASS_HOST_DEVICE bool operator<=(int32_t other) const {
@@ -141,58 +190,103 @@ struct NA1dDim {
   }
 
   CUTLASS_HOST_DEVICE int32_t prod32() const {
-    return x;
+    return (int32_t)x;
   }
 };
 
-struct NA2dDim {
-  int32_t x;
-  int32_t y;
+template <typename T>
+struct NA2dDimT {
+  T x;
+  T y;
 
   // Default ctor
-  CUTLASS_HOST_DEVICE constexpr NA2dDim(int32_t x_, int32_t y_)
-      : x(x_), y(y_) {}
+  CUTLASS_HOST_DEVICE constexpr NA2dDimT(T x_, T y_) : x(x_), y(y_) {}
 
-  CUTLASS_HOST_DEVICE NA2dDim() : x(0), y(0) {}
+  CUTLASS_HOST_DEVICE NA2dDimT() : x(0), y(0) {}
 
-  CUTLASS_HOST_DEVICE void operator=(const NA2dDim& other) {
+  CUTLASS_HOST_DEVICE void operator=(const NA2dDimT& other) {
     x = other.x;
     y = other.y;
   }
 
-  // CUTLASS_HOST_DEVICE NA2dDim(int32_t n): x(n), y(n) {}
+  // CUTLASS_HOST_DEVICE NA2dDimT(T n): x(n), y(n) {}
 
   // Operators
-  CUTLASS_HOST_DEVICE NA2dDim operator+(NA2dDim other) const {
-    return NA2dDim(x + other.x, y + other.y);
+  CUTLASS_HOST_DEVICE NA2dDimT operator+(NA2dDimT other) const {
+    return NA2dDimT(x + other.x, y + other.y);
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator*(NA2dDim other) const {
-    return NA2dDim(x * other.x, y * other.y);
+  CUTLASS_HOST_DEVICE NA2dDimT operator*(NA2dDimT other) const {
+    return NA2dDimT(x * other.x, y * other.y);
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator-(NA2dDim other) const {
-    return NA2dDim(x - other.x, y - other.y);
+  CUTLASS_HOST_DEVICE NA2dDimT operator-(NA2dDimT other) const {
+    return NA2dDimT(x - other.x, y - other.y);
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator/(NA2dDim other) const {
-    return NA2dDim(x / other.x, y / other.y);
+  CUTLASS_HOST_DEVICE NA2dDimT operator/(NA2dDimT other) const {
+    return NA2dDimT(x / other.x, y / other.y);
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator+(int32_t other) const {
-    return NA2dDim(x + other, y + other);
+  // Cross-T binary ops; promote to common_type<T, U>.
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA2dDimT<typename std::common_type<T, U>::type> operator+(
+      NA2dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA2dDimT<R>(
+        static_cast<R>(x) + static_cast<R>(other.x),
+        static_cast<R>(y) + static_cast<R>(other.y));
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator*(int32_t other) const {
-    return NA2dDim(x * other, y * other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA2dDimT<typename std::common_type<T, U>::type> operator*(
+      NA2dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA2dDimT<R>(
+        static_cast<R>(x) * static_cast<R>(other.x),
+        static_cast<R>(y) * static_cast<R>(other.y));
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator-(int32_t other) const {
-    return NA2dDim(x - other, y - other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA2dDimT<typename std::common_type<T, U>::type> operator-(
+      NA2dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA2dDimT<R>(
+        static_cast<R>(x) - static_cast<R>(other.x),
+        static_cast<R>(y) - static_cast<R>(other.y));
   }
 
-  CUTLASS_HOST_DEVICE NA2dDim operator/(int32_t other) const {
-    return NA2dDim(x / other, y / other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA2dDimT<typename std::common_type<T, U>::type> operator/(
+      NA2dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA2dDimT<R>(
+        static_cast<R>(x) / static_cast<R>(other.x),
+        static_cast<R>(y) / static_cast<R>(other.y));
+  }
+
+  CUTLASS_HOST_DEVICE NA2dDimT operator+(int32_t other) const {
+    return NA2dDimT(x + other, y + other);
+  }
+
+  CUTLASS_HOST_DEVICE NA2dDimT operator*(int32_t other) const {
+    return NA2dDimT(x * other, y * other);
+  }
+
+  CUTLASS_HOST_DEVICE NA2dDimT operator-(int32_t other) const {
+    return NA2dDimT(x - other, y - other);
+  }
+
+  CUTLASS_HOST_DEVICE NA2dDimT operator/(int32_t other) const {
+    return NA2dDimT(x / other, y / other);
   }
 
   // Cmp
@@ -212,7 +306,7 @@ struct NA2dDim {
   //  return x >= other.x && y >= other.y;
   //}
 
-  CUTLASS_HOST_DEVICE bool operator==(NA2dDim other) const {
+  CUTLASS_HOST_DEVICE bool operator==(NA2dDimT other) const {
     return x == other.x && y == other.y;
   }
 
@@ -220,8 +314,8 @@ struct NA2dDim {
   // coordinate exceeds the spatial extent. This is used in
   // the NA mask (`get_window_start`).
   // It should NOT overload the >= operator.
-  CUTLASS_HOST_DEVICE NA2dDim is_overflowing(NA2dDim extent) const {
-    return NA2dDim(x >= extent.x, y >= extent.y);
+  CUTLASS_HOST_DEVICE NA2dDimT is_overflowing(NA2dDimT extent) const {
+    return NA2dDimT(x >= extent.x, y >= extent.y);
   }
 
   // CUTLASS_HOST_DEVICE bool operator<=(int32_t other) const {
@@ -246,68 +340,118 @@ struct NA2dDim {
 
   // Reduce
   CUTLASS_HOST_DEVICE int64_t sum() const {
-    return (int64_t)(x + y);
+    return (int64_t)x + (int64_t)y;
   }
 
   CUTLASS_HOST_DEVICE int64_t prod() const {
-    return (int64_t)(x * y);
+    return (int64_t)x * (int64_t)y;
   }
 
   CUTLASS_HOST_DEVICE int32_t prod32() const {
-    return x * y;
+    return (int32_t)x * (int32_t)y;
   }
 };
 
-struct NA3dDim {
-  int32_t x;
-  int32_t y;
-  int32_t z;
+template <typename T>
+struct NA3dDimT {
+  T x;
+  T y;
+  T z;
 
   // Default ctor
-  CUTLASS_HOST_DEVICE constexpr NA3dDim(int32_t x_, int32_t y_, int32_t z_)
+  CUTLASS_HOST_DEVICE constexpr NA3dDimT(T x_, T y_, T z_)
       : x(x_), y(y_), z(z_) {}
 
-  CUTLASS_HOST_DEVICE NA3dDim() : x(0), y(0), z(0) {}
+  CUTLASS_HOST_DEVICE NA3dDimT() : x(0), y(0), z(0) {}
 
-  CUTLASS_HOST_DEVICE void operator=(const NA3dDim& other) {
+  CUTLASS_HOST_DEVICE void operator=(const NA3dDimT& other) {
     x = other.x;
     y = other.y;
     z = other.z;
   }
 
-  // CUTLASS_HOST_DEVICE NA3dDim(int32_t n): x(n), y(n), z(n) {}
+  // CUTLASS_HOST_DEVICE NA3dDimT(T n): x(n), y(n), z(n) {}
 
   // Operators
-  CUTLASS_HOST_DEVICE NA3dDim operator+(NA3dDim other) const {
-    return NA3dDim(x + other.x, y + other.y, z + other.z);
+  CUTLASS_HOST_DEVICE NA3dDimT operator+(NA3dDimT other) const {
+    return NA3dDimT(x + other.x, y + other.y, z + other.z);
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator*(NA3dDim other) const {
-    return NA3dDim(x * other.x, y * other.y, z * other.z);
+  CUTLASS_HOST_DEVICE NA3dDimT operator*(NA3dDimT other) const {
+    return NA3dDimT(x * other.x, y * other.y, z * other.z);
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator-(NA3dDim other) const {
-    return NA3dDim(x - other.x, y - other.y, z - other.z);
+  CUTLASS_HOST_DEVICE NA3dDimT operator-(NA3dDimT other) const {
+    return NA3dDimT(x - other.x, y - other.y, z - other.z);
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator/(NA3dDim other) const {
-    return NA3dDim(x / other.x, y / other.y, z / other.z);
+  CUTLASS_HOST_DEVICE NA3dDimT operator/(NA3dDimT other) const {
+    return NA3dDimT(x / other.x, y / other.y, z / other.z);
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator+(int32_t other) const {
-    return NA3dDim(x + other, y + other, z + other);
+  // Cross-T binary ops; promote to common_type<T, U>.
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA3dDimT<typename std::common_type<T, U>::type> operator+(
+      NA3dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA3dDimT<R>(
+        static_cast<R>(x) + static_cast<R>(other.x),
+        static_cast<R>(y) + static_cast<R>(other.y),
+        static_cast<R>(z) + static_cast<R>(other.z));
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator*(int32_t other) const {
-    return NA3dDim(x * other, y * other, z * other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA3dDimT<typename std::common_type<T, U>::type> operator*(
+      NA3dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA3dDimT<R>(
+        static_cast<R>(x) * static_cast<R>(other.x),
+        static_cast<R>(y) * static_cast<R>(other.y),
+        static_cast<R>(z) * static_cast<R>(other.z));
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator-(int32_t other) const {
-    return NA3dDim(x - other, y - other, z - other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA3dDimT<typename std::common_type<T, U>::type> operator-(
+      NA3dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA3dDimT<R>(
+        static_cast<R>(x) - static_cast<R>(other.x),
+        static_cast<R>(y) - static_cast<R>(other.y),
+        static_cast<R>(z) - static_cast<R>(other.z));
   }
 
-  CUTLASS_HOST_DEVICE NA3dDim operator/(int32_t other) const {
-    return NA3dDim(x / other, y / other, z / other);
+  template <
+      typename U,
+      typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+  CUTLASS_HOST_DEVICE NA3dDimT<typename std::common_type<T, U>::type> operator/(
+      NA3dDimT<U> other) const {
+    using R = typename std::common_type<T, U>::type;
+    return NA3dDimT<R>(
+        static_cast<R>(x) / static_cast<R>(other.x),
+        static_cast<R>(y) / static_cast<R>(other.y),
+        static_cast<R>(z) / static_cast<R>(other.z));
+  }
+
+  CUTLASS_HOST_DEVICE NA3dDimT operator+(int32_t other) const {
+    return NA3dDimT(x + other, y + other, z + other);
+  }
+
+  CUTLASS_HOST_DEVICE NA3dDimT operator*(int32_t other) const {
+    return NA3dDimT(x * other, y * other, z * other);
+  }
+
+  CUTLASS_HOST_DEVICE NA3dDimT operator-(int32_t other) const {
+    return NA3dDimT(x - other, y - other, z - other);
+  }
+
+  CUTLASS_HOST_DEVICE NA3dDimT operator/(int32_t other) const {
+    return NA3dDimT(x / other, y / other, z / other);
   }
 
   // Cmp
@@ -327,7 +471,7 @@ struct NA3dDim {
   //  return x >= other.x && y >= other.y && z >= other.z;
   //}
 
-  CUTLASS_HOST_DEVICE bool operator==(NA3dDim other) const {
+  CUTLASS_HOST_DEVICE bool operator==(NA3dDimT other) const {
     return x == other.x && y == other.y && z == other.z;
   }
 
@@ -335,8 +479,8 @@ struct NA3dDim {
   // coordinate exceeds the spatial extent. This is used in
   // the NA mask (`get_window_start`).
   // It should NOT overload the >= operator.
-  CUTLASS_HOST_DEVICE NA3dDim is_overflowing(NA3dDim extent) const {
-    return NA3dDim(x >= extent.x, y >= extent.y, z >= extent.z);
+  CUTLASS_HOST_DEVICE NA3dDimT is_overflowing(NA3dDimT extent) const {
+    return NA3dDimT(x >= extent.x, y >= extent.y, z >= extent.z);
   }
 
   // CUTLASS_HOST_DEVICE bool operator<=(int32_t other) const {
@@ -361,17 +505,29 @@ struct NA3dDim {
 
   // Reduce
   CUTLASS_HOST_DEVICE int64_t sum() const {
-    return (int64_t)(x + y + z);
+    return (int64_t)x + (int64_t)y + (int64_t)z;
   }
 
   CUTLASS_HOST_DEVICE int64_t prod() const {
-    return (int64_t)(x * y * z);
+    return (int64_t)x * (int64_t)y * (int64_t)z;
   }
 
   CUTLASS_HOST_DEVICE int32_t prod32() const {
-    return x * y * z;
+    return (int32_t)x * (int32_t)y * (int32_t)z;
   }
 };
+
+// Public aliases. NA{1,2,3}dDim is the int32 coord/extent variant; the
+// existing per-rank free function specializations (fast_min, ceil_div_dim,
+// etc.) below resolve to these. NA{1,2,3}dStride is the int64 byte-stride
+// variant returned by compute_stride.
+using NA1dDim = NA1dDimT<int32_t>;
+using NA2dDim = NA2dDimT<int32_t>;
+using NA3dDim = NA3dDimT<int32_t>;
+
+using NA1dStride = NA1dDimT<int64_t>;
+using NA2dStride = NA2dDimT<int64_t>;
+using NA3dStride = NA3dDimT<int64_t>;
 
 template <int NADim>
 struct GetDim;
@@ -389,6 +545,24 @@ struct GetDim<2> {
 template <>
 struct GetDim<3> {
   using type = NA3dDim;
+};
+
+template <int NADim>
+struct GetStride;
+
+template <>
+struct GetStride<1> {
+  using type = NA1dStride;
+};
+
+template <>
+struct GetStride<2> {
+  using type = NA2dStride;
+};
+
+template <>
+struct GetStride<3> {
+  using type = NA3dStride;
 };
 
 // data structure conversions
@@ -707,27 +881,27 @@ CUTLASS_HOST_DEVICE NA3dDim div_dim(NA3dDim lhs, NA3dDim rhs) {
   return NA3dDim(lhs.x / rhs.x, lhs.y / rhs.y, lhs.z / rhs.z);
 }
 
-template <typename Dim>
-CUTLASS_HOST_DEVICE Dim compute_stride(Dim input_shape, int64_t last_stride);
-
-template <>
-CUTLASS_HOST_DEVICE NA1dDim
+// compute_stride returns the int64 NAxdStride variant so subsequent
+// stride * coord products are evaluated in int64 and don't overflow int32
+// even when individual stride values themselves still fit in int32. The 3D
+// case also casts the leading shape product to int64 explicitly to guard
+// against int32 overflow within the stride computation itself for very large
+// shapes.
+CUTLASS_HOST_DEVICE NA1dStride
 compute_stride(NA1dDim input_shape, int64_t last_stride) {
-  return NA1dDim(last_stride);
+  return NA1dStride(last_stride);
 }
 
-template <>
-CUTLASS_HOST_DEVICE NA2dDim
+CUTLASS_HOST_DEVICE NA2dStride
 compute_stride(NA2dDim input_shape, int64_t last_stride) {
-  return NA2dDim(input_shape.y * last_stride, last_stride);
+  return NA2dStride((int64_t)input_shape.y * last_stride, last_stride);
 }
 
-template <>
-CUTLASS_HOST_DEVICE NA3dDim
+CUTLASS_HOST_DEVICE NA3dStride
 compute_stride(NA3dDim input_shape, int64_t last_stride) {
-  return NA3dDim(
-      input_shape.y * input_shape.z * last_stride,
-      input_shape.z * last_stride,
+  return NA3dStride(
+      (int64_t)input_shape.y * input_shape.z * last_stride,
+      (int64_t)input_shape.z * last_stride,
       last_stride);
 }
 


### PR DESCRIPTION
token layout strides should be encoded in int64 for safety; left-most stride can get pretty big, especially if users go beyond the typical 128 head dim, and have high token counts on the right.

Some small regressions (up to ~ 15%) are expected.

Fixes #335.