### PR TITLE
Fix int32 offset overflow in compute-delta reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Main branch]
+* Fixed int32 address-offset overflow in the CUTLASS `dO * O` reduction
+  kernel for large sequence lengths.
 
 ## [0.21.7] - 2026-07-26
 * Switched to int64 strides in cutlass-fna to avoid overflows in larger use cases.

--- a/csrc/include/natten/cuda/reduction/compute_delta.cuh
+++ b/csrc/include/natten/cuda/reduction/compute_delta.cuh
@@ -54,16 +54,18 @@ void compute_delta(
   OperationSumOdO op_sum_OdO;
 
   ProblemShape problem_shape = cute::make_tuple(batch, heads, seqlen_Q, dim);
-  auto stride_O = make_stride(
-      static_cast<int64_t>(dim * heads) * static_cast<int64_t>(seqlen_Q),
-      dim,
-      dim * heads,
-      _1{});
+  // Keep dynamic strides int64-typed so device-side coordinate * stride
+  // address arithmetic is evaluated in 64 bits.
+  const int64_t q_stride =
+      static_cast<int64_t>(dim) * static_cast<int64_t>(heads);
+  const int64_t batch_stride = q_stride * static_cast<int64_t>(seqlen_Q);
+  auto stride_O =
+      make_stride(batch_stride, static_cast<int64_t>(dim), q_stride, _1{});
   auto stride_dO = stride_O;
   auto stride_sum_OdO = make_stride(
       static_cast<int64_t>(heads) * static_cast<int64_t>(seqlen_Q),
       _1{},
-      heads);
+      static_cast<int64_t>(heads));
 
   auto args = typename OperationSumOdO::Arguments{
       problem_shape,

--- a/csrc/include/natten/cuda/reduction/fmha_kernel_bwd_sum_OdO.hpp
+++ b/csrc/include/natten/cuda/reduction/fmha_kernel_bwd_sum_OdO.hpp
@@ -47,12 +47,12 @@ struct FmhaKernelBwdSumOdO {
     ProblemShape problem_shape;
 
     const Element* ptr_O;
-    cute::tuple<int64_t, int, int, cute::_1> stride_O;
+    cute::tuple<int64_t, int64_t, int64_t, cute::_1> stride_O;
     const Element* ptr_dO;
-    cute::tuple<int64_t, int, int, cute::_1> stride_dO;
+    cute::tuple<int64_t, int64_t, int64_t, cute::_1> stride_dO;
 
     ElementAcc* ptr_sum_OdO;
-    cute::tuple<int64_t, _1, int> stride_sum_OdO;
+    cute::tuple<int64_t, _1, int64_t> stride_sum_OdO;
   };
 
   using Params = Arguments;


### PR DESCRIPTION
Fixes #347

The CUTLASS compute-delta reduction (`compute_delta.cuh` / `fmha_kernel_bwd_sum_OdO.hpp`) stored the dynamic Q-stride components of `O`, `dO`, and `delta` as `int`. Device-side expressions such as:

```cpp
idx_q * get<2>(params.stride_O)
```

were therefore evaluated in 32-bit arithmetic. For sufficiently long sequences, the coordinate-times-stride product overflows even though the Q-stride value itself fits in int32.

For heads-last `[B, Q, H, D]` tensors, the `O`/`dO` Q stride is `H * D`, and the overflow occurs once:

```text
(Q - 1) * H * D > INT32_MAX
```

At `H=16` and `D=64`, `Q=2,097,153` is the first overflowing sequence length, while `Q=2,097,152` remains safe.

This change:

- stores all dynamic `O`, `dO`, and `delta` stride components as `int64_t`, making device-side coordinate-times-stride address arithmetic 64-bit;
- constructs the host-side Q and batch stride products without int32 intermediate multiplication.

This addresses the same class of large-offset overflow as #337's int64 widening of the CUTLASS FNA iterator strides; the standalone compute-delta reduction was not covered there.

There are no API changes.

## Validation

Tested on SM90 with CUDA 12.8, PyTorch 2.11, fp16, `kernel_size=511`, and `backend="cutlass-fna"` explicitly selected. The reference used the same build and inputs with `backward_use_pt_reduction=True`. The maximum absolute difference between two repeated reference runs was approximately `9.8e-4` at these shapes.

- `B=1`, `H=16`, `D=64`, `Q=2,097,153` (`2,147,484,672` `O`/`dO` elements):
- pre-fix dQ/dK differ from the reference by approximately 55x / 8x the repeated-reference baseline;
- with the fix, they match at the baseline.
- `Q=2,300,000` (`2,355,200,000` elements):
- pre-fix deviations are approximately 850-900x the baseline;
- with the fix, they match at the baseline.
- `Q=2,097,152`, the exact last-safe length, matches at the baseline on both the pre-fix and fixed builds, pinning the boundary.
- `dV` is bit-unaffected at every tested length on both builds, consistent with `delta` feeding only the dQ/dK softmax-correction term.
- Tested below-boundary shapes are bit-identical before and after the change.
- The full FNA/FMHA test suites pass unchanged.

Reproducing the boundary through the public backward path requires more than `2^31` fp16 elements in each of `O` and `dO`, or just over 4 GiB per tensor. The full backward/reference validation above peaked at approximately 68 GiB, so this case is not suitable for the regular CI suite.

## Performance

No measurable regression was observed in the tested SM90 configuration.