### PR TITLE
Fix torch.compile self-attention fallback logging

### DIFF
--- a/src/natten/functional.py
+++ b/src/natten/functional.py
@@ -408,8 +408,13 @@ def neighborhood_attention_generic(
         has_additional_attention=has_additional_attention,
     ):
         logger.debug(
-            f"{query.shape=} with {kernel_size=}, {has_additional_attention=} and {is_causal=} is "
-            "self attention. Calling attention instead of neighborhood attention directly."
+            "query.shape=%s with kernel_size=%s, has_additional_attention=%s and "
+            "is_causal=%s is self attention. Calling attention instead of neighborhood "
+            "attention directly.",
+            query.shape,
+            kernel_size,
+            has_additional_attention,
+            is_causal,
         )
 
         query_shape = query.shape

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -192,6 +192,32 @@ class Block(nn.Module):
 
 
 class TorchCompileTests(unittest.TestCase):
+    @skip_if_libnatten_is_not_supported()
+    def test_dynamic_compile_self_attention_fallback(self):
+        _reset_everything()
+
+        query = torch.randn(
+            (1, 8, 8, 1, 64), device="cuda", dtype=torch.float16
+        )
+
+        def self_attention_fallback(query):
+            return neighborhood_attention_generic(
+                query,
+                query,
+                query,
+                kernel_size=(8, 8),
+            )
+
+        compiled = torch.compile(
+            self_attention_fallback,
+            backend="eager",
+            fullgraph=True,
+            dynamic=True,
+        )
+        output = compiled(query)
+
+        self.assertEqual(output.shape, query.shape)
+
     def _test_na_module(
         self,
         batch,


### PR DESCRIPTION
Fixes #345.

Current self-attention fallback formats `query.shape` in an f-string before `NattenLogger` can skip logging during `torch.compile`. With dynamic shapes, this invokes `repr` on Dynamo's `SizeVariable` and breaks full-graph compilation.

This PR uses lazy logging arguments so the symbolic shape is not formatted while tracing. Also adds a focused regression test that captures the shared self-attention fallback with dynamic shapes and a full graph, independently of Inductor and kernel code generation.

Tested with:

```
python -m pytest -q tests/test_torch_compile.py::TorchCompileTests::test_dynamic_compile_self_attention_fallback tests/test_log.py
```

20 passed.
